### PR TITLE
converting get functions from actions to getters

### DIFF
--- a/src/mixin/mixin.js
+++ b/src/mixin/mixin.js
@@ -1,11 +1,13 @@
 import getActions from "../store/actions";
 import getState from "../store/state";
 import getValidationFunctions from "../store/validation";
-import getFilterHelperFunctions from "../store/filters";
-import getChartHelperFunctions from "../store/charts";
+import getGetters from "../store/getters";
 import getDataHelperFunctions from "../store/data";
+import { getFilterActions, getFilterGetters } from "../store/filters";
+import { getChartActions, getChartGetters } from "../store/charts";
+// import getDataHelperFunctions from "../store/data";
 import harnessStore from "../store/harnessStore";
-import { mapActions, mapState, mapGetters } from "pinia";
+import { mapActions, mapState } from "pinia";
 
 export default function mixin(pinia) {
   return {
@@ -38,13 +40,18 @@ export default function mixin(pinia) {
         // const pageStore = pageFunc();
         const pageDefinition = harnessMetadata.getpageDefinitions[waypoint];
         //   const pageDefinition = { key: "foo" };
-        const state = getAttributeNames(getState(pageDefinition));
+        const stateAndGetters = getAttributeNames({
+          ...getState(pageDefinition),
+          ...getGetters(pageDefinition),
+          ...getFilterGetters(),
+          ...getChartGetters(),
+          ...getDataHelperFunctions(),
+          ...getValidationFunctions(),
+        });
         const actions = getAttributeNames({
           ...getActions(pageDefinition),
-          ...getValidationFunctions(),
-          ...getFilterHelperFunctions(),
-          ...getChartHelperFunctions(),
-          ...getDataHelperFunctions(),
+          ...getFilterActions(),
+          ...getChartActions(),
         });
         this.$options.methods = {
           ...this.$options.methods,
@@ -52,8 +59,7 @@ export default function mixin(pinia) {
         };
         this.$options.computed = {
           ...this.$options.computed,
-          ...mapState(pageFunc, state),
-          ...mapGetters(pageFunc, state),
+          ...mapState(pageFunc, stateAndGetters),
           pageStore() {
             return pageFunc(pinia);
           },

--- a/src/store/charts.js
+++ b/src/store/charts.js
@@ -1,16 +1,18 @@
 import { capitalize } from "./utils";
 import { saveAs } from "file-saver";
 
-export default function getChartHelperFunctions() {
+export function getChartGetters() {
   return {
     /**
      * Returns the chart object for a given key
      *
      * @param  {String} key a chart key
      */
-    getChartDefinition(key) {
-      this._validChartKey(key);
-      return this.charts[key];
+    getChartDefinition(state) {
+      return (key) => {
+        state._validChartKey(key);
+        return state.charts[key];
+      };
     },
 
     /**
@@ -18,19 +20,11 @@ export default function getChartHelperFunctions() {
      *
      * @param  {String} key a chart key
      */
-    getChartData(key) {
-      this._validChartKey(key);
-      return this[`get${capitalize(key)}ChartData`];
-    },
-
-    /**
-     * Sets data for a given chart
-     *
-     * @param  {String} key a chart key
-     */
-    setChartData(key, payload) {
-      this._validChartKey(key);
-      this[`set${capitalize(key)}ChartData`](payload);
+    getChartData(state) {
+      return (key) => {
+        state._validChartKey(key);
+        return state[`get${capitalize(key)}ChartData`];
+      };
     },
 
     /**
@@ -38,9 +32,11 @@ export default function getChartHelperFunctions() {
      *
      * @param  {String} key a chart key
      */
-    getChartDataActionString(key) {
-      this._validChartKey(key);
-      return `set${capitalize(key)}ChartData`;
+    getChartDataActionString(state) {
+      return (key) => {
+        state._validChartKey(key);
+        return `set${capitalize(key)}ChartData`;
+      };
     },
 
     /**
@@ -48,9 +44,11 @@ export default function getChartHelperFunctions() {
      *
      * @param  {String} key a chart key
      */
-    getChartProps(key) {
-      this._validChartKey(key);
-      return this.charts[key].props;
+    getChartProps(state) {
+      return (key) => {
+        state._validChartKey(key);
+        return state.charts[key].props;
+      };
     },
 
     /**
@@ -59,35 +57,51 @@ export default function getChartHelperFunctions() {
      * @param  {any} data the data to be validated. If null, it will not validate (for lifecyle)
      * @param  {} key the key for this data's chart
      */
-    validateChartData(data, key) {
-      this._validChartKey(key);
-      if (data) {
-        if (!Array.isArray(data)) {
-          let msg = "The processed data for " + key + " is not an array.";
-          if (!this.getChartProps(key).tableAdapter) {
-            msg +=
-              " Please add a tableAdapter function to your chart that processes it for tabular representation.";
-          }
-          throw String(msg);
-        }
-        if (data.length < 1) {
-          throw String("The processed data for " + key + " has no content.");
-        }
-        data.forEach((row) => {
-          if (typeof row !== "object") {
-            let msg =
-              "The processed data for " +
-              key +
-              " contains non-object elements.";
-            if (!this.getChartProps(key).tableAdapter) {
+    validateChartData(state) {
+      return (data, key) => {
+        state._validChartKey(key);
+        if (data) {
+          if (!Array.isArray(data)) {
+            let msg = "The processed data for " + key + " is not an array.";
+            if (!state.getChartProps(key).tableAdapter) {
               msg +=
                 " Please add a tableAdapter function to your chart that processes it for tabular representation.";
             }
             throw String(msg);
           }
-        });
-      }
-      return data;
+          if (data.length < 1) {
+            throw String("The processed data for " + key + " has no content.");
+          }
+          data.forEach((row) => {
+            if (typeof row !== "object") {
+              let msg =
+                "The processed data for " +
+                key +
+                " contains non-object elements.";
+              if (!state.getChartProps(key).tableAdapter) {
+                msg +=
+                  " Please add a tableAdapter function to your chart that processes it for tabular representation.";
+              }
+              throw String(msg);
+            }
+          });
+        }
+        return data;
+      };
+    },
+  };
+}
+
+export function getChartActions() {
+  return {
+    /**
+     * Sets data for a given chart
+     *
+     * @param  {String} key a chart key
+     */
+    setChartData(key, payload) {
+      this._validChartKey(key);
+      this[`set${capitalize(key)}ChartData`](payload);
     },
 
     /**

--- a/src/store/createHarnessStore.js
+++ b/src/store/createHarnessStore.js
@@ -3,8 +3,8 @@ import getActions from "./actions";
 import getState from "./state";
 import getGetters from "./getters";
 import getValidationFunctions from "./validation";
-import getFilterHelperFunctions from "./filters";
-import getChartHelperFunctions from "./charts";
+import { getFilterGetters, getFilterActions } from "./filters";
+import { getChartGetters, getChartActions } from "./charts";
 import getDataHelperFunctions from "./data";
 import subscribeActions from "./subscriptions";
 
@@ -12,13 +12,17 @@ export default function createHarnessStore(pageDefinition, options) {
   // options syntax
   const storeFunc = defineStore(pageDefinition.key, {
     state: () => getState(pageDefinition),
-    getters: getGetters(pageDefinition),
+    getters: {
+      ...getGetters(pageDefinition),
+      ...getFilterGetters(),
+      ...getChartGetters(),
+      ...getDataHelperFunctions(),
+      ...getValidationFunctions(),
+    },
     actions: {
       ...getActions(pageDefinition),
-      ...getValidationFunctions(),
-      ...getFilterHelperFunctions(),
-      ...getChartHelperFunctions(),
-      ...getDataHelperFunctions(),
+      ...getFilterActions(),
+      ...getChartActions(),
     },
   });
   const store = storeFunc(options.pinia);

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -5,14 +5,15 @@ export default function getDataHelperFunctions() {
      * @param  {Array/String} data an array of data arrays, or a string representing a chart data key
      * @param  {} idx the key to use for either the object attribute or array column you are trying to get values for
      */
-    getValues(data, idx) {
-      data = this._validateData(data);
-      return data.reduce((acc, datum) => {
-        acc.push(datum[idx]);
-        return acc;
-      }, []);
+    getValues(state) {
+      return (data, idx) => {
+        data = state._validateData(data);
+        return data.reduce((acc, datum) => {
+          acc.push(datum[idx]);
+          return acc;
+        }, []);
+      };
     },
-
     /**
      * Returns an array of distinct values from an array of arrays or objects by index. If values are strings or numbers they will be sorted, and if an optional array of values is provided as a map it will be used to sort.
      *
@@ -20,69 +21,75 @@ export default function getDataHelperFunctions() {
      * @param  {String/Number} idx=null the key to use for either the object attribute or array column you are trying to get distinct values for
      * @param  {Array} map=null an array of values to use as an ordering map in sort
      */
-    getDistinctValues(data, idx = null, map = null) {
-      data = this._validateData(data);
-      // extract distinct values
-      if (idx) {
-        data = this.getValues(data, idx);
-      }
-      return data
-        .reduce((acc, datum) => {
-          if (!acc.includes(datum)) {
-            acc.push(datum);
-          }
-          return acc;
-        }, [])
-        .sort((a, b) => {
-          if (map) {
-            // sort by map
-            return map.indexOf(a) - map.indexOf(b);
-          } else if (typeof a === "string" && typeof b === "string") {
-            // sort strings
-            return a.localeCompare(b, "en", { sensitivity: "base" });
-          }
-        });
+    getDistinctValues(state) {
+      return (data, idx = null, map = null) => {
+        data = state._validateData(data);
+        // extract distinct values
+        if (idx) {
+          data = state.getValues(data, idx);
+        }
+        return data
+          .reduce((acc, datum) => {
+            if (!acc.includes(datum)) {
+              acc.push(datum);
+            }
+            return acc;
+          }, [])
+          .sort((a, b) => {
+            if (map) {
+              // sort by map
+              return map.indexOf(a) - map.indexOf(b);
+            } else if (typeof a === "string" && typeof b === "string") {
+              // sort strings
+              return a.localeCompare(b, "en", { sensitivity: "base" });
+            }
+          });
+      };
     },
     /**
      * Applies the value(s) of a harness filter to a column in a given set of data and returns the filtered result
      * @param  {String} filter a key representing a harness filter
      * @param  {String/Number} column the column/attribute in the data to apply the filter to
      * @param  {Array/String} data an array of data arrays, or a string representing a chart data key
-     * @param  {String} allKey=null a string representing a potential value for "all". If this is variable is present in the filter, the filter is not applied
+     * @param  {String} allKey=null a string representing a potential value for "all". If state is variable is present in the filter, the filter is not applied
      */
-    applyFilterToColumn(filter, column, data, allKey = null) {
-      // if data is string, get chart data
-      data = this._validateData(data);
-      const filterValue = this.getFilter(filter);
-      if (!filterValue) {
-        throw String("Filter value is empty");
-      }
+    applyFilterToColumn(state) {
+      return (filter, column, data, allKey = null) => {
+        // if data is string, get chart data
+        data = state._validateData(data);
+        const filterValue = state.getFilter(filter);
+        if (!filterValue) {
+          throw String("Filter value is empty");
+        }
 
-      return data.filter((datum) => {
-        // handle 'multiple' filters where value is an array
-        if (Array.isArray(filterValue)) {
-          const match = filterValue.includes(datum[column]);
+        return data.filter((datum) => {
+          // handle 'multiple' filters where value is an array
+          if (Array.isArray(filterValue)) {
+            const match = filterValue.includes(datum[column]);
+            if (allKey) {
+              return filterValue.includes(allKey) || match;
+            }
+            return match;
+          }
+          // handle normal filters with a single value
+          const match = filterValue === datum[column];
           if (allKey) {
-            return filterValue.includes(allKey) || match;
+            return filterValue === allKey || match;
           }
           return match;
-        }
-        // handle normal filters with a single value
-        const match = filterValue === datum[column];
-        if (allKey) {
-          return filterValue === allKey || match;
-        }
-        return match;
-      });
+        });
+      };
     },
     /**
      * Gets the minimum value from an array of data. If an index is supplied, gets the minimum for that index/attribute in the data. Only includes valid numbers in calculations.
      * @param  {Array/String} data an array of data/data arrays, or a string representing a chart data key
      * @param  {String/Number} idx=null the optional index/attribute in the data to apply the filter to
      */
-    getMin(data, idx = null) {
-      data = this._onlyValidNumbers(data, idx);
-      return Math.min(...data);
+    getMin(state) {
+      return (data, idx = null) => {
+        data = state._onlyValidNumbers(data, idx);
+        return Math.min(...data);
+      };
     },
 
     /**
@@ -90,9 +97,11 @@ export default function getDataHelperFunctions() {
      * @param  {Array/String} data an array of data/data arrays, or a string representing a chart data key
      * @param  {String/Number} idx=null the optional index/attribute in the data to apply the filter to
      */
-    getMax(data, idx = null) {
-      data = this._onlyValidNumbers(data, idx);
-      return Math.max(...data);
+    getMax(state) {
+      return (data, idx = null) => {
+        data = state._onlyValidNumbers(data, idx);
+        return Math.max(...data);
+      };
     },
 
     /**
@@ -100,12 +109,14 @@ export default function getDataHelperFunctions() {
      * @param  {Array/String} data an array of data/data arrays, or a string representing a chart data key.  Only includes valid numbers in calculations.
      * @param  {String/Number} idx=null the optional index/attribute in the data to apply the filter to
      */
-    getMedian(data, idx = null) {
-      data = this._onlyValidNumbers(data, idx).sort((a, b) => a - b);
-      const midpoint = Math.floor(data.length / 2);
-      return data.length % 2 !== 0
-        ? data[midpoint]
-        : (data[midpoint - 1] + data[midpoint]) / 2;
+    getMedian(state) {
+      return (data, idx = null) => {
+        data = state._onlyValidNumbers(data, idx).sort((a, b) => a - b);
+        const midpoint = Math.floor(data.length / 2);
+        return data.length % 2 !== 0
+          ? data[midpoint]
+          : (data[midpoint - 1] + data[midpoint]) / 2;
+      };
     },
 
     /**
@@ -113,9 +124,11 @@ export default function getDataHelperFunctions() {
      * @param  {Array/String} data an array of data/data arrays, or a string representing a chart data key
      * @param  {String/Number} idx=null the optional index/attribute in the data to apply the filter to
      */
-    getSum(data, idx = null) {
-      data = this._onlyValidNumbers(data, idx);
-      return data.reduce((acc, datum) => acc + datum);
+    getSum(state) {
+      return (data, idx = null) => {
+        data = state._onlyValidNumbers(data, idx);
+        return data.reduce((acc, datum) => acc + datum);
+      };
     },
 
     /**
@@ -123,9 +136,11 @@ export default function getDataHelperFunctions() {
      * @param  {Array/String} data an array of data/data arrays, or a string representing a chart data key
      * @param  {String/Number} idx=null the optional index/attribute in the data to apply the filter to
      */
-    getMean(data, idx = null) {
-      data = this._onlyValidNumbers(data, idx);
-      return this.getSum(data) / data.length;
+    getMean(state) {
+      return (data, idx = null) => {
+        data = state._onlyValidNumbers(data, idx);
+        return state.getSum(data) / data.length;
+      };
     },
 
     /**
@@ -133,29 +148,31 @@ export default function getDataHelperFunctions() {
      * @param  {Array/String} data an array of data/data arrays, or a string representing a chart data key
      * @param  {String/Number} idx=null the optional index/attribute in the data to apply the filter to
      */
-    getGeometricMean(data, idx = null) {
-      data = this._onlyValidNumbers(data, idx);
-      const changePcts = [];
-      data.forEach((datum, datumIdx) => {
-        if (datumIdx + 1 < data.length) {
-          const datum1val = parseInt(datum) || 0;
-          const datum2val = parseInt(data[datumIdx + 1]) || 0;
-          if (datum1val && datum2val) {
-            // ignore zeroes
-            if (datum1val === datum2val) {
-              changePcts.push(1);
-            } else {
-              const change = datum2val - datum1val;
-              const pctChange = 1 + (change * 100) / datum1val / 100; // convert change percent to decimal relative to 1. ie 3% becomes 1.03, -3% becomes 0.97
-              changePcts.push(pctChange);
+    getGeometricMean(state) {
+      return (data, idx = null) => {
+        data = state._onlyValidNumbers(data, idx);
+        const changePcts = [];
+        data.forEach((datum, datumIdx) => {
+          if (datumIdx + 1 < data.length) {
+            const datum1val = parseInt(datum) || 0;
+            const datum2val = parseInt(data[datumIdx + 1]) || 0;
+            if (datum1val && datum2val) {
+              // ignore zeroes
+              if (datum1val === datum2val) {
+                changePcts.push(1);
+              } else {
+                const change = datum2val - datum1val;
+                const pctChange = 1 + (change * 100) / datum1val / 100; // convert change percent to decimal relative to 1. ie 3% becomes 1.03, -3% becomes 0.97
+                changePcts.push(pctChange);
+              }
             }
           }
-        }
-      });
-      let geoMean = changePcts.reduce((acc, pct) => acc * pct, 1); // multiply all change percents, starting with a baseline of 1
-      geoMean = Math.pow(geoMean, 1 / changePcts.length) - 1; // get nth root of product n=length
-      geoMean = geoMean * 100; // unpack back to a percent
-      return geoMean;
+        });
+        let geoMean = changePcts.reduce((acc, pct) => acc * pct, 1); // multiply all change percents, starting with a baseline of 1
+        geoMean = Math.pow(geoMean, 1 / changePcts.length) - 1; // get nth root of product n=length
+        geoMean = geoMean * 100; // unpack back to a percent
+        return geoMean;
+      };
     },
 
     /**
@@ -163,27 +180,29 @@ export default function getDataHelperFunctions() {
      * @param  {Array/String} data an array of data/data arrays, or a string representing a chart data key
      * @param  {String/Number} idx=null the optional index/attribute in the data to apply the filter to
      */
-    getQuartiles(data, idx = null) {
-      data = this._onlyValidNumbers(data, idx).sort((a, b) => a - b);
-      const intervals = [0.25, 0.5, 0.75];
-      const quartileIntervals = intervals.reduce((final, interval) => {
-        const position = data.length * interval;
-        const floor = Math.floor(position);
+    getQuartiles(state) {
+      return (data, idx = null) => {
+        data = state._onlyValidNumbers(data, idx).sort((a, b) => a - b);
+        const intervals = [0.25, 0.5, 0.75];
+        const quartileIntervals = intervals.reduce((final, interval) => {
+          const position = data.length * interval;
+          const floor = Math.floor(position);
 
-        if (floor === position) {
-          final.push((data[floor - 1] + data[floor]) / 2);
-        } else {
-          final.push(data[floor]);
-        }
-        return final;
-      }, []);
-      return {
-        minimum: this.getMin(data),
-        lowerQuartile: quartileIntervals[0],
-        median: quartileIntervals[1],
-        upperQuartile: quartileIntervals[2],
-        maximum: this.getMax(data),
-        IQR: quartileIntervals[2] - quartileIntervals[0],
+          if (floor === position) {
+            final.push((data[floor - 1] + data[floor]) / 2);
+          } else {
+            final.push(data[floor]);
+          }
+          return final;
+        }, []);
+        return {
+          minimum: state.getMin(data),
+          lowerQuartile: quartileIntervals[0],
+          median: quartileIntervals[1],
+          upperQuartile: quartileIntervals[2],
+          maximum: state.getMax(data),
+          IQR: quartileIntervals[2] - quartileIntervals[0],
+        };
       };
     },
 
@@ -193,33 +212,35 @@ export default function getDataHelperFunctions() {
      * @param  {Array/String} data an array of data/data arrays, or a string representing a chart data key
      * @param  {String/Number} idx=null the optional index/attribute in the data to apply the filter to
      */
-    getOutliers(data, idx = null) {
-      if (idx) {
-        data = this._validateData(data).sort((a, b) => a[idx] - b[idx]);
-        data = data.filter((datum) => {
-          const parsed = Number(datum[idx]);
-          return (
-            datum[idx] === parsed &&
-            typeof parsed === "number" &&
-            !isNaN(parsed) &&
-            isFinite(parsed)
+    getOutliers(state) {
+      return (data, idx = null) => {
+        if (idx) {
+          data = state._validateData(data).sort((a, b) => a[idx] - b[idx]);
+          data = data.filter((datum) => {
+            const parsed = Number(datum[idx]);
+            return (
+              datum[idx] === parsed &&
+              typeof parsed === "number" &&
+              !isNaN(parsed) &&
+              isFinite(parsed)
+            );
+          });
+        } else {
+          data = state._onlyValidNumbers(data, idx).sort((a, b) => a - b);
+        }
+        const quartiles = state.getQuartiles(data, idx);
+        const lowerBound = quartiles["lowerQuartile"] - 1.5 * quartiles["IQR"];
+        const upperBound = quartiles["upperQuartile"] + 1.5 * quartiles["IQR"];
+        if (idx) {
+          return data.filter(
+            (datum) => datum[idx] <= lowerBound || datum[idx] >= upperBound
           );
-        });
-      } else {
-        data = this._onlyValidNumbers(data, idx).sort((a, b) => a - b);
-      }
-      const quartiles = this.getQuartiles(data, idx);
-      const lowerBound = quartiles["lowerQuartile"] - 1.5 * quartiles["IQR"];
-      const upperBound = quartiles["upperQuartile"] + 1.5 * quartiles["IQR"];
-      if (idx) {
-        return data.filter(
-          (datum) => datum[idx] <= lowerBound || datum[idx] >= upperBound
-        );
-      } else {
-        return data.filter(
-          (datum) => datum <= lowerBound || datum >= upperBound
-        );
-      }
+        } else {
+          return data.filter(
+            (datum) => datum <= lowerBound || datum >= upperBound
+          );
+        }
+      };
     },
 
     /**
@@ -228,31 +249,35 @@ export default function getDataHelperFunctions() {
      * @param  {Array/String} data an array of data/data arrays, or a string representing a chart data key
      * @param  {String/Number} idx=null the optional index/attribute in the data to apply the filter to
      */
-    removeOutliers(data, idx = null) {
-      if (idx) {
-        data = this._validateData(data).sort((a, b) => a[idx] - b[idx]);
-        data = data.filter((datum) => {
-          const parsed = Number(datum[idx]);
-          return (
-            datum[idx] === parsed &&
-            typeof parsed === "number" &&
-            !isNaN(parsed) &&
-            isFinite(parsed)
+    removeOutliers(state) {
+      return (data, idx = null) => {
+        if (idx) {
+          data = state._validateData(data).sort((a, b) => a[idx] - b[idx]);
+          data = data.filter((datum) => {
+            const parsed = Number(datum[idx]);
+            return (
+              datum[idx] === parsed &&
+              typeof parsed === "number" &&
+              !isNaN(parsed) &&
+              isFinite(parsed)
+            );
+          });
+        } else {
+          data = state._onlyValidNumbers(data, idx).sort((a, b) => a - b);
+        }
+        const quartiles = state.getQuartiles(data, idx);
+        const lowerBound = quartiles["lowerQuartile"] - 1.5 * quartiles["IQR"];
+        const upperBound = quartiles["upperQuartile"] + 1.5 * quartiles["IQR"];
+        if (idx) {
+          return data.filter(
+            (datum) => datum[idx] > lowerBound && datum[idx] < upperBound
           );
-        });
-      } else {
-        data = this._onlyValidNumbers(data, idx).sort((a, b) => a - b);
-      }
-      const quartiles = this.getQuartiles(data, idx);
-      const lowerBound = quartiles["lowerQuartile"] - 1.5 * quartiles["IQR"];
-      const upperBound = quartiles["upperQuartile"] + 1.5 * quartiles["IQR"];
-      if (idx) {
-        return data.filter(
-          (datum) => datum[idx] > lowerBound && datum[idx] < upperBound
-        );
-      } else {
-        return data.filter((datum) => datum > lowerBound && datum < upperBound);
-      }
+        } else {
+          return data.filter(
+            (datum) => datum > lowerBound && datum < upperBound
+          );
+        }
+      };
     },
   };
 }

--- a/src/store/filters.js
+++ b/src/store/filters.js
@@ -1,18 +1,187 @@
 import { capitalize } from "./utils";
 import getDefaultOption from "./defaultOption";
 
-export default function getFilterHelperFunctions() {
+export function getFilterGetters() {
   return {
     /**
      * Returns the value for a given filter
      * @param  {String} key a filter key
      * @memberof module:Filters
      */
-    getFilter(key) {
-      this._validFilterKey(key);
-      return this[`get${capitalize(key)}Filter`];
+    getFilter(state) {
+      return (key) => {
+        state._validFilterKey(key);
+        return state[`get${capitalize(key)}Filter`];
+      };
+    },
+    /**
+     * Returns the full action string for a given filter. Useful for checking in subscriptions
+     *
+     * @param  {String} key a filter key
+     */
+    getFilterActionString(state) {
+      return (key) => {
+        state._validFilterKey(key);
+        return `set${capitalize(key)}Filter`;
+      };
     },
 
+    /**
+     * Returns the filter object for a given filter key
+     *
+     * @param  {String} key a filter key
+     */
+    getFilterDefinition(state) {
+      return (key) => {
+        state._validFilterKey(key);
+        return state.getFilters[key];
+      };
+    },
+
+    /**
+     * returns the props for a given filter, if they exist
+     *
+     * @param  {String} key a filter key
+     */
+    getFilterProps(state) {
+      return (key) => {
+        state._validFilterKey(key);
+        return state.filters[key].props;
+      };
+    },
+
+    /**
+     * Returns the label for a given filter
+     *
+     * @param  {String} key a filter key
+     */
+    getLabel(state) {
+      return (key) => {
+        state._validFilterKey(key);
+        return state.filters[key] ? state.filters[key].label : null;
+      };
+    },
+
+    /**
+     * Returns the options array for a given filter
+     *
+     * @param  {String} key a filter key
+     */
+    getOptionsForFilter(state) {
+      return (key) => {
+        state._validFilterKey(key);
+        return state[`${key}Options`];
+      };
+    },
+
+    /**
+     * Returns the label for a given option by key
+     *
+     * @param  {String} filter a filter key
+     * @param  {String} key an option key for an option included in the filter
+     */
+    getLabelForOptionKey(state) {
+      return (filter, key) => {
+        state._validFilterKey(filter);
+        const options = state.getOptionsForFilter(filter) || [];
+        const option = options.filter((o) => {
+          return o.key === key;
+        })[0];
+        return option ? option.label : null;
+      };
+    },
+
+    /**
+     * Returns the label for a filter's selected option
+     *
+     * @param  {String} key a filter key
+     */
+    getLabelForSelectedOption(state) {
+      return (key) => {
+        state._validFilterKey(key);
+        return state.getLabelForOptionKey(key, state.getFilter(key)) || null;
+      };
+    },
+    /**
+     * Returns the default option for a given filter
+     *
+     * @param  {String} key a filter key
+     */
+    getFilterDefault(state) {
+      return (key) => {
+        state._validFilterKey(key);
+        const filter = state.filters[key];
+        const options = state.getOptionsForFilter(key);
+        return getDefaultOption(filter, options);
+      };
+    },
+
+    /**
+     * Returns the label for the default option for a given filter
+     *
+     * @param  {String} key a filter key
+     */
+    getFilterDefaultLabel(state) {
+      (key) => {
+        state._validFilterKey(key);
+        return state.getLabelForOptionKey(
+          state.filters[key],
+          state.getFilterDefault(key)
+        );
+      };
+    },
+
+    /**
+     * Returns a boolean indicating whether or not the value of state filter is equal to the value of the default. If true, the filter is no longer set to default.
+     *
+     * @param  {String} key a filter key
+     */
+    isFilterDirty(state) {
+      return (key) => {
+        state._validFilterKey(key);
+        return (
+          JSON.stringify(state.getFilterDefault(key)) !==
+          JSON.stringify(state.getFilter(key))
+        );
+      };
+    },
+
+    /**
+     * Returns a boolean indicating whether or not any filters on the page have been set to a value other than their default
+     *
+     */
+    areFiltersDirty(state) {
+      return () => {
+        return Object.keys(state.filters).reduce(
+          function (final, filter) {
+            if (final === false) {
+              return state.isFilterDirty(filter);
+            }
+            return final;
+          }.bind(state),
+          false
+        );
+      };
+    },
+
+    /**
+     * Returns an array of filter keys for dirty filters
+     *
+     */
+    getDirtyFilters(state) {
+      return () => {
+        return Object.keys(state.filters).filter(
+          function (filter) {
+            return state.isFilterDirty(filter);
+          }.bind(state)
+        );
+      };
+    },
+  };
+}
+
+export function getFilterActions() {
+  return {
     /**
      * Sets a given filter's value
      *
@@ -22,56 +191,6 @@ export default function getFilterHelperFunctions() {
     setFilter(key, payload) {
       this._validFilterKey(key);
       this[`set${capitalize(key)}Filter`](payload);
-    },
-
-    /**
-     * Returns the full action string for a given filter. Useful for checking in subscriptions
-     *
-     * @param  {String} key a filter key
-     */
-    getFilterActionString(key) {
-      this._validFilterKey(key);
-      return `set${capitalize(key)}Filter`;
-    },
-
-    /**
-     * Returns the filter object for a given filter key
-     *
-     * @param  {String} key a filter key
-     */
-    getFilterDefinition(key) {
-      this._validFilterKey(key);
-      return this.getFilters[key];
-    },
-
-    /**
-     * returns the props for a given filter, if they exist
-     *
-     * @param  {String} key a filter key
-     */
-    getFilterProps(key) {
-      this._validFilterKey(key);
-      return this.filters[key].props;
-    },
-
-    /**
-     * Returns the label for a given filter
-     *
-     * @param  {String} key a filter key
-     */
-    getLabel(key) {
-      this._validFilterKey(key);
-      return this.filters[key] ? this.filters[key].label : null;
-    },
-
-    /**
-     * Returns the options array for a given filter
-     *
-     * @param  {String} key a filter key
-     */
-    getOptionsForFilter(key) {
-      this._validFilterKey(key);
-      return this[`${key}Options`];
     },
 
     /**
@@ -88,31 +207,6 @@ export default function getFilterHelperFunctions() {
       if (setDefaultOption) {
         this.setFilter(key, this.getFilterDefault(key));
       }
-    },
-
-    /**
-     * Returns the label for a given option by key
-     *
-     * @param  {String} filter a filter key
-     * @param  {String} key an option key for an option included in the filter
-     */
-    getLabelForOptionKey(filter, key) {
-      this._validFilterKey(filter);
-      const options = this.getOptionsForFilter(filter) || [];
-      const option = options.filter((o) => {
-        return o.key === key;
-      })[0];
-      return option ? option.label : null;
-    },
-
-    /**
-     * Returns the label for a filter's selected option
-     *
-     * @param  {String} key a filter key
-     */
-    getLabelForSelectedOption(key) {
-      this._validFilterKey(key);
-      return this.getLabelForOptionKey(key, this.getFilter(key)) || null;
     },
 
     /**
@@ -178,72 +272,6 @@ export default function getFilterHelperFunctions() {
     showOptions(filter, optionKeys) {
       this._validFilterKey(filter);
       this.setOptionPropertyToBoolean(filter, optionKeys, "hidden", false);
-    },
-
-    /**
-     * Returns the default option for a given filter
-     *
-     * @param  {String} key a filter key
-     */
-    getFilterDefault(key) {
-      this._validFilterKey(key);
-      const filter = this.filters[key];
-      const options = this.getOptionsForFilter(key);
-      return getDefaultOption(filter, options);
-    },
-
-    /**
-     * Returns the label for the default option for a given filter
-     *
-     * @param  {String} key a filter key
-     */
-    getFilterDefaultLabel(key) {
-      this._validFilterKey(key);
-      return this.getLabelForOptionKey(
-        this.filters[key],
-        this.getFilterDefault(key)
-      );
-    },
-
-    /**
-     * Returns a boolean indicating whether or not the value of this filter is equal to the value of the default. If true, the filter is no longer set to default.
-     *
-     * @param  {String} key a filter key
-     */
-    isFilterDirty(key) {
-      this._validFilterKey(key);
-      return (
-        JSON.stringify(this.getFilterDefault(key)) !==
-        JSON.stringify(this.getFilter(key))
-      );
-    },
-
-    /**
-     * Returns a boolean indicating whether or not any filters on the page have been set to a value other than their default
-     *
-     */
-    areFiltersDirty() {
-      return Object.keys(this.filters).reduce(
-        function (final, filter) {
-          if (final === false) {
-            return this.isFilterDirty(filter);
-          }
-          return final;
-        }.bind(this),
-        false
-      );
-    },
-
-    /**
-     * Returns an array of filter keys for dirty filters
-     *
-     */
-    getDirtyFilters() {
-      return Object.keys(this.filters).filter(
-        function (filter) {
-          return this.isFilterDirty(filter);
-        }.bind(this)
-      );
     },
   };
 }

--- a/src/store/validation.js
+++ b/src/store/validation.js
@@ -1,44 +1,52 @@
 export default function getValidationFunctions() {
   return {
-    _validateData(data, idx = null) {
-      if (typeof data === "string") {
-        data = this.getChartData(data);
-      }
-      if (!data) {
-        throw String("Data array is empty");
-      }
-      if (!Array.isArray(data)) {
-        throw String("Data is not an array");
-      }
-      if (idx) {
-        data = this.getValues(data, idx);
-      }
-      return data;
+    _validateData(state) {
+      return (data, idx = null) => {
+        if (typeof data === "string") {
+          data = state.getChartData(data);
+        }
+        if (!data) {
+          throw String("Data array is empty");
+        }
+        if (!Array.isArray(data)) {
+          throw String("Data is not an array");
+        }
+        if (idx) {
+          data = state.getValues(data, idx);
+        }
+        return data;
+      };
     },
 
-    _validFilterKey(key) {
-      if (!Object.keys(this.getFilters).includes(key)) {
-        throw String(key + " is not a valid filter");
-      }
+    _validFilterKey(state) {
+      return (key) => {
+        if (!Object.keys(state.getFilters).includes(key)) {
+          throw String(key + " is not a valid filter");
+        }
+      };
     },
 
-    _validChartKey(key) {
-      if (!Object.keys(this.getCharts).includes(key)) {
-        throw String(key + " is not a valid chart");
-      }
+    _validChartKey(state) {
+      return (key) => {
+        if (!Object.keys(state.getCharts).includes(key)) {
+          throw String(key + " is not a valid chart");
+        }
+      };
     },
 
-    _onlyValidNumbers(data, idx = null) {
-      data = this._validateData(data, idx);
-      return data.filter((d) => {
-        const parsed = Number(d);
-        return (
-          d === parsed &&
-          typeof parsed === "number" &&
-          !isNaN(parsed) &&
-          isFinite(parsed)
-        );
-      });
+    _onlyValidNumbers(state) {
+      return (data, idx = null) => {
+        data = state._validateData(data, idx);
+        return data.filter((d) => {
+          const parsed = Number(d);
+          return (
+            d === parsed &&
+            typeof parsed === "number" &&
+            !isNaN(parsed) &&
+            isFinite(parsed)
+          );
+        });
+      };
     },
   };
 }


### PR DESCRIPTION
This PR addresses some performance issues related to vue-devtools. Moving from our old model of a separate `Hs` class that wraps helper functions to including helper functions as part of the Pinia state had the unintended side effect of pushing a significant amount of helper functions and getters into actions. Vue Devtools tracks each of these actions in memory which leads to significant performance issues in local dev. 

This branch converts all "get" functions and helper functions like validation and data manipulation to use pinia getters with arguments.