### PR TITLE
Unsort distinct

### DIFF
--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -20,7 +20,7 @@ Returns all values in a given data key/attribute, unsorted
 
 <a name="getDistinctValues"></a>
 
-## getDistinctValues(data, idx, map)
+## getDistinctValues(data, idx, map, sort)
 Returns an array of distinct values from an array of arrays or objects by index. If values are strings or numbers they will be sorted, and if an optional array of values is provided as a map it will be used to sort. Sorting can be disabled by setting <code>sort = false</code>.
 
 **Kind**: global function  
@@ -30,7 +30,7 @@ Returns an array of distinct values from an array of arrays or objects by index.
 | data | <code>Array/String</code> |  | an array of data arrays, or a string representing a chart data key |
 | idx | <code>String/Number</code> | <code></code> | the key to use for either the object attribute or array column you are trying to get distinct values for |
 | map | <code>Array</code> | <code></code> | an array of values to use as an ordering map in sort |
-| sort | <code>Boolean</code> | <code>true</code> | boolean to check whether to sort the returning distinct values
+| sort | <code>Boolean</code> | <code>true</code> | boolean to check whether to sort the returning distinct values |
 
 <a name="applyFilterToColumn"></a>
 

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -21,7 +21,7 @@ Returns all values in a given data key/attribute, unsorted
 <a name="getDistinctValues"></a>
 
 ## getDistinctValues(data, idx, map)
-Returns an array of distinct values from an array of arrays or objects by index. If values are strings or numbers they will be sorted, and if an optional array of values is provided as a map it will be used to sort.
+Returns an array of distinct values from an array of arrays or objects by index. If values are strings or numbers they will be sorted, and if an optional array of values is provided as a map it will be used to sort. Sorting can be disabled by setting <code>sort = false</code>.
 
 **Kind**: global function  
 
@@ -30,6 +30,7 @@ Returns an array of distinct values from an array of arrays or objects by index.
 | data | <code>Array/String</code> |  | an array of data arrays, or a string representing a chart data key |
 | idx | <code>String/Number</code> | <code></code> | the key to use for either the object attribute or array column you are trying to get distinct values for |
 | map | <code>Array</code> | <code></code> | an array of values to use as an ordering map in sort |
+| sort | <code>Boolean</code> | <code>true</code> | boolean to check whether to sort the returning distinct values
 
 <a name="applyFilterToColumn"></a>
 

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -20,22 +20,24 @@ export default function getDataHelperFunctions() {
      * @param  {Array/String} data an array of data arrays, or a string representing a chart data key
      * @param  {String/Number} idx=null the key to use for either the object attribute or array column you are trying to get distinct values for
      * @param  {Array} map=null an array of values to use as an ordering map in sort
+     * @param  {Boolean} sort=true boolean to check whether to sort the returning distinct values
      */
     getDistinctValues(state) {
-      return (data, idx = null, map = null) => {
+      return (data, idx = null, map = null, sort = true) => {
         data = state._validateData(data);
         // extract distinct values
         if (idx) {
           data = state.getValues(data, idx);
         }
-        return data
+        data = data
           .reduce((acc, datum) => {
             if (!acc.includes(datum)) {
               acc.push(datum);
             }
             return acc;
           }, [])
-          .sort((a, b) => {
+        return sort ? 
+          data.sort((a, b) => {
             if (map) {
               // sort by map
               return map.indexOf(a) - map.indexOf(b);
@@ -43,7 +45,7 @@ export default function getDataHelperFunctions() {
               // sort strings
               return a.localeCompare(b, "en", { sensitivity: "base" });
             }
-          });
+          }) : data;
       };
     },
     /**

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -15,7 +15,7 @@ export default function getDataHelperFunctions() {
       };
     },
     /**
-     * Returns an array of distinct values from an array of arrays or objects by index. If values are strings or numbers they will be sorted, and if an optional array of values is provided as a map it will be used to sort.
+     * Returns an array of distinct values from an array of arrays or objects by index. If values are strings or numbers they will be sorted, and if an optional array of values is provided as a map it will be used to sort. Sorting can be disabled by setting <code>sort = false</code>.
      *
      * @param  {Array/String} data an array of data arrays, or a string representing a chart data key
      * @param  {String/Number} idx=null the key to use for either the object attribute or array column you are trying to get distinct values for

--- a/tests/data.spec.js
+++ b/tests/data.spec.js
@@ -29,6 +29,7 @@ describe("DV Data Helpers", () => {
     "1.01",
     new Date(),
   ];
+  let outOfOrderArrayFlat = [4, 1, 3, 1, 2, 4]
   it("Can Validate Data", () => {
     let hs = mockHs();
 
@@ -110,6 +111,24 @@ describe("DV Data Helpers", () => {
     // test subset map
     let bigMap = [...map, "five", "six"];
     expect(hs.getDistinctValues(dataArray, "test", bigMap)).toEqual(map);
+  });
+
+  it("Can Get Distinct Unsorted Values From Data", () => {
+    let hs = mockHs();
+    // test strings
+    expect(hs.getDistinctValues(dataArray, "test", null, false)).toEqual([
+      "one",
+      "two",
+      "three",
+      "four",
+    ]);
+
+    // test flat
+    expect(hs.getDistinctValues(dataArrayFlat)).toEqual([1, 2, 3, 4]);
+    // test out of order flat
+    expect(hs.getDistinctValues(outOfOrderArrayFlat)).toEqual([4, 1, 3, 2]);
+    // test nums
+    expect(hs.getDistinctValues(dataArrayNum, "test")).toEqual([1, 2, 3, 4]);
   });
 
   it("Can Apply Filter To Column", () => {


### PR DESCRIPTION
This PR is designed to allow developers to decide whether the values returned from `getDistinctValues()` are sorted. The idea being that if you already have chronologically sorted data, it would be more convenient to get the distinct values in that same order.