### PR TITLE
adding composable and documentation

### DIFF
--- a/docs/api-stubs/metadata.md
+++ b/docs/api-stubs/metadata.md
@@ -18,5 +18,5 @@ These functions can be useful for things such as navigation or other tasks that 
 To access the store, import from the main library:
 
 ```js
-import { harnessStore } from "@rtidatascience/harness-vue"
+import { useHarnessStore } from "@rtidatascience/harness-vue"
 ```

--- a/docs/api/metadata.md
+++ b/docs/api/metadata.md
@@ -18,5 +18,5 @@ These functions can be useful for things such as navigation or other tasks that 
 To access the store, import from the main library:
 
 ```js
-import { harnessStore } from "@rtidatascience/harness-vue"
+import { useHarnessStore } from "@rtidatascience/harness-vue"
 ```

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -47,19 +47,21 @@ app.use(harnessPlugin, { pinia, pages, router })
 app.use(router);
 app.mount("#app");
 ```
+## Automagic Page Stores
+One of the goals of Harness-Vue is the ability to write components that are widely reusable across pages, charts and filters - having an API of helper functions that provide contextualized actions on each page is a convenience feature that allows for more robust and reusable components. In order to assist in that process, Harness-Vue exports a global mixin for the options API and a composable for the composition API that detect what page your component is currently referring to using the following logic:
 
-## Options API mixin
-The Harness-Vue package in its first release is intended for use with the Vue Options API. Harness-Vue includes a global mixin that does the following:
+  * first by checking if the route name (if vue-router is used) matches the name of an installed page definition
+  * second by checking if there is only one page and no vue-router installed and using that by default
+  * third by checking for a `harness-waypoint` prop that matches a page definition key
 
-* attempts to locate what page to contextualize the component to
-  * first by checking if the route name (if router provided) matches the name of an installed page definition
-  * second by checking if there is only one page installed and using that by default
-  * third by checking for a `harness-waypoint` prop that matches a page
 
-If the mixin detects a match, all of the available Harness-Vue API functions are mapped to the component using the [mapState](https://pinia.vuejs.org/core-concepts/state.html#usage-with-the-options-api) and [mapActions](https://pinia.vuejs.org/core-concepts/actions.html#without-setup) functions from Pinia. This enables developers to write components that are page-agnostic as described in the "Why Harness-Vue" section of the about page.
+### Options API mixin
+
+If the mixin detects a match, all of the available Harness-Vue API functions are mapped to the component using the [mapState](https://pinia.vuejs.org/core-concepts/state.html#usage-with-the-options-api) and [mapActions](https://pinia.vuejs.org/core-concepts/actions.html#without-setup) functions from Pinia. Using this mixin makes all Harness API functions available in the `this` context in your component.
 
 To install the mixin, import it from the core library and install it as a mixin.
 
+`main.js`
 ```js
 import { harnessPlugin, harnessMixin } from "@rtidatascience/harness-vue"
 // pages? more on this later!
@@ -73,4 +75,49 @@ app.use(pinia)
 app.use(harnessPlugin, { pinia, pages, router })
 app.mixin(harnessMixin(pinia));
 app.mount("#app");
+```
+
+Component Example:
+```js
+<template>
+  <div>
+    {{ getChartData(chartKey) }}
+  </div>
+</template>
+<script>
+  export default {
+    name: 'chart',
+    props: {
+      chartKey: {
+        required: true,
+        type: String
+      }
+    }
+  }
+</script>
+```
+
+## Composable
+For the composition API, Harness-Vue publishes a composable that follows the logic defined above to determine the page and returns the appropriate pinia store for you to use. 
+
+Component example:
+```vue 
+<template>
+  <div>
+    {{ harness.getChartData(chart.key) }}
+  </div>
+</template>
+
+<script setup>
+import { defineProps } from "vue";
+import { harnessComposable } from "@rtidatascience/harness-vue";
+defineProps({
+  chart: {
+    type: Object,
+    required: true,
+  },
+});
+const harness = harnessComposable();
+</script>
+
 ```

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -110,14 +110,14 @@ Component example:
 
 <script setup>
 import { defineProps } from "vue";
-import { harnessComposable } from "@rtidatascience/harness-vue";
+import { useHarnessComposable } from "@rtidatascience/harness-vue";
 defineProps({
   chart: {
     type: Object,
     required: true,
   },
 });
-const harness = harnessComposable();
+const harness = useHarnessComposable();
 </script>
 
 ```

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -97,7 +97,7 @@ Component Example:
 </script>
 ```
 
-## Composable
+### Composable
 For the composition API, Harness-Vue publishes a composable that follows the logic defined above to determine the page and returns the appropriate pinia store for you to use. 
 
 Component example:

--- a/src/composable/composable.js
+++ b/src/composable/composable.js
@@ -1,9 +1,9 @@
 // https://stackoverflow.com/questions/72209080/vue-3-is-getcurrentinstance-deprecated
 import { getCurrentInstance } from "vue";
-import { harnessStore } from "../harness";
+import { useHarnessStore } from "../harness";
 
 export default function harnessComposable() {
-  const harnessMetadata = harnessStore();
+  const harnessMetadata = useHarnessStore();
   const vueInstance = getCurrentInstance();
 
   let waypoint = false;

--- a/src/composable/composable.js
+++ b/src/composable/composable.js
@@ -1,0 +1,38 @@
+// https://stackoverflow.com/questions/72209080/vue-3-is-getcurrentinstance-deprecated
+import { getCurrentInstance } from "vue";
+import { harnessStore } from "../harness";
+
+export default function harnessComposable() {
+  const harnessMetadata = harnessStore();
+  const vueInstance = getCurrentInstance();
+
+  let waypoint = false;
+
+  // check for a vue-router route
+  if (
+    vueInstance.appContext.config.globalProperties.$route?.name &&
+    harnessMetadata.getPages.includes(
+      vueInstance.appContext.config.globalProperties.$route.name
+    )
+  ) {
+    waypoint = vueInstance.appContext.config.globalProperties.$route.name;
+  }
+
+  // if router is not installed and only a single harness page exists, use it as waypoint
+  if (
+    (harnessMetadata.getPages.length === 1) &
+    !vueInstance.appContext.config.globalProperties.$route
+  ) {
+    waypoint = harnessMetadata.pages[0];
+  }
+
+  // // if a waypoint override was specified, use that
+  if (vueInstance.attrs["harness-waypoint"]) {
+    waypoint = vueInstance.attrs["harness-waypoint"];
+  }
+
+  if (waypoint) {
+    return harnessMetadata.getPageStores[waypoint]();
+  }
+  return waypoint;
+}

--- a/src/composable/composable.js
+++ b/src/composable/composable.js
@@ -2,7 +2,7 @@
 import { getCurrentInstance } from "vue";
 import { useHarnessStore } from "../harness";
 
-export default function harnessComposable() {
+export default function useHarnessComposable() {
   const harnessMetadata = useHarnessStore();
   const vueInstance = getCurrentInstance();
 

--- a/src/harness.js
+++ b/src/harness.js
@@ -3,6 +3,7 @@ import harnessStore from "./store/harnessStore";
 import createHarnessStore from "./store/createHarnessStore";
 import createHarnessRoute from "./router/route.js";
 import harnessMixin from "./mixin/mixin.js";
+import harnessComposable from "./composable/composable";
 const harnessPlugin = {
   install: (app, options) => {
     // create harness metadata store in pinia
@@ -30,4 +31,4 @@ const harnessPlugin = {
   },
 };
 
-export { harnessPlugin, harnessMixin, harnessStore };
+export { harnessPlugin, harnessMixin, harnessStore, harnessComposable };

--- a/src/harness.js
+++ b/src/harness.js
@@ -1,5 +1,5 @@
 import pages from "./validation/pages";
-import harnessStore from "./store/harnessStore";
+import useHarnessStore from "./store/harnessStore";
 import createHarnessStore from "./store/createHarnessStore";
 import createHarnessRoute from "./router/route.js";
 import harnessMixin from "./mixin/mixin.js";
@@ -7,7 +7,7 @@ import harnessComposable from "./composable/composable";
 const harnessPlugin = {
   install: (app, options) => {
     // create harness metadata store in pinia
-    const harness = harnessStore(options.pinia);
+    const harness = useHarnessStore(options.pinia);
 
     // validate page files
     const validatedPages = pages(options.pages);
@@ -31,4 +31,4 @@ const harnessPlugin = {
   },
 };
 
-export { harnessPlugin, harnessMixin, harnessStore, harnessComposable };
+export { harnessPlugin, harnessMixin, useHarnessStore, harnessComposable };

--- a/src/harness.js
+++ b/src/harness.js
@@ -3,7 +3,7 @@ import useHarnessStore from "./store/harnessStore";
 import createHarnessStore from "./store/createHarnessStore";
 import createHarnessRoute from "./router/route.js";
 import harnessMixin from "./mixin/mixin.js";
-import harnessComposable from "./composable/composable";
+import useHarnessComposable from "./composable/composable";
 const harnessPlugin = {
   install: (app, options) => {
     // create harness metadata store in pinia
@@ -31,4 +31,4 @@ const harnessPlugin = {
   },
 };
 
-export { harnessPlugin, harnessMixin, useHarnessStore, harnessComposable };
+export { harnessPlugin, harnessMixin, useHarnessStore, useHarnessComposable };

--- a/src/mixin/mixin.js
+++ b/src/mixin/mixin.js
@@ -6,7 +6,7 @@ import getDataHelperFunctions from "../store/data";
 import { getFilterActions, getFilterGetters } from "../store/filters";
 import { getChartActions, getChartGetters } from "../store/charts";
 // import getDataHelperFunctions from "../store/data";
-import harnessStore from "../store/harnessStore";
+import useHarnessStore from "../store/harnessStore";
 import { mapActions, mapState } from "pinia";
 
 export default function mixin(pinia) {
@@ -15,7 +15,7 @@ export default function mixin(pinia) {
       // if route name is a valid harness page, use it as waypoint
       let waypoint = false;
 
-      const harnessMetadata = harnessStore(pinia);
+      const harnessMetadata = useHarnessStore(pinia);
 
       if (
         this.$route &&

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,5 +1,5 @@
 import { capitalize } from "./utils";
-import metadataStore from "./harnessStore";
+import useHarnessStore from "./harnessStore";
 import getDefaultOption from "./defaultOption";
 export default function getActions(pageDefinition) {
   const actions = {
@@ -15,7 +15,7 @@ export default function getActions(pageDefinition) {
           "loadData function is missing in page file. loadData must exist to use LOAD_DATA action"
         );
       }
-      const harnessStore = metadataStore();
+      const harnessStore = useHarnessStore();
       const pageStore = harnessStore.getPageStores[pageDefinition.key]();
       const data = await pageDefinition
         .loadData(pageDefinition, pageStore)

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import pages from "./mocks/pages/manifest";
-import { harnessStore } from "../src/harness";
+import { useHarnessStore } from "../src/harness";
 import createHarnessStore from "../src/store/createHarnessStore";
 import { createPinia } from "pinia";
 
@@ -9,7 +9,7 @@ const page = new pages[0]();
 
 function mockHs() {
   const pinia = createPinia();
-  const harness = harnessStore(pinia);
+  const harness = useHarnessStore(pinia);
   const pageFunc = createHarnessStore(page, pinia);
   const pageStore = pageFunc(pinia);
   harness.addStore(page.key, page, pageFunc);


### PR DESCRIPTION
This PR adds a composable that provides similar automatic page detection as the options API mixin. 

My struggle in implementing this was that the options API mixin is able to access the router by checking for `this.$router`, whereas composables/composition has no `this` context to do similarly. And we don't require the use of vue-router, so I can't import it to check the route without making it a forced dependency. I did some searching and found the `getCurrentInstance` vue method. See [here](https://programeasily.com/2021/02/24/getcurrentinstance-in-vue-3/) and [here](https://stackoverflow.com/questions/72209080/vue-3-is-getcurrentinstance-deprecated). It would appear that they have removed this API function from documentation, but it's widely in use in official Vue packages to the point that I'm not worried about it disappearing. Additionally, this composable is an optional convenience feature, and [documentation exists](https://harnessjs.org/api/metadata.html) on how to access the individual stores without this helper.