### PR TITLE
adding arbitrary extension feature

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -22,6 +22,7 @@ export default {
                     {text: 'The loadData Lifecycle', link: '/usage/lifecycle'},
                     {text: 'Working with Charts', link: '/usage/charts'},
                     {text: 'Working with Filters', link: '/usage/filters'},
+                    {text: "Extending the Store", link: '/usage/extending'},
                 ]
             },
             {

--- a/docs/usage/extending.md
+++ b/docs/usage/extending.md
@@ -1,0 +1,99 @@
+# Extending The Harness-Vue Store
+
+Given that the Harness-Vue store is a pinia instance, there are times in which it is useful for a developer to extend the store itself with additional arbitrary values. In order to do so, harness-vue will consume extended getters, actions, state and subscription if included in the page definition.
+
+## Getters
+To add getters to the pinia store, provide an `extendGetters` attribute to your page definition. These getters should conform to [the expected Pinia getter syntax](https://pinia.vuejs.org/core-concepts/getters.html).
+
+```js
+export default class ExamplePage {
+    filters = () => {
+        return {
+            startDate: {},
+            endDate: {}
+        }
+    }
+    extendGetters = () => {
+        return {
+            getDateRangeString(state) {
+                return `${state.getFilter('startDate')} - ${state.getFilter('endDate')}`;
+            }
+        }
+    }
+}
+```
+```js
+pageStore.setFilter("startDate", "01-01-2024")
+pageStore.setFilter("endDate", "01-31-2024")
+console.log(pageStore.getDateRangeString)
+// "01-01-2024 - 01-31-2024"
+```
+
+## Actions
+To add actions to the pinia store, provide an `extendActions` attribute to your page definition. These getters should conform to [the expected Pinia action syntax](https://pinia.vuejs.org/core-concepts/actions.html).
+
+```js
+export default class ExamplePage {
+    filters = () => {
+            return {
+                filter1: {options: [{key: "first", label: "first"}]}
+            }
+    }
+
+    extendActions = () => {
+        return {
+            async addOptionsToFilter(filterKey){
+                const options = await fetch(`/options/${filterKey}`).then(d => d.json())
+                const optionMap = options.map((option) => ({key: option, label: option}))
+                const finalOptions = [...this.getOptionsForFilter(filterKey), ...optionMap]
+                this.setOptionsForFilter(filterKey, finalOptions)
+            }
+        }
+    }
+}
+```
+```js
+// expecting server to return ["second", "third"]
+pageStore.addOptionsToFilter("filter1")
+console.log(pageStore.getOptionsForFilter("filter1"))
+// [
+//  {key: "first", label: "first"},
+//  {key: "second", label: "second"},
+//  {key: "third", label: "third"},
+// ]
+```
+
+## State
+To add to the state in the pinia store, provide an `extendState` attribute to your page definition. These returned object should conform to [the expected Pinia state syntax](https://pinia.vuejs.org/core-concepts/state.html).
+
+```js
+import {ref} from "vue"
+export default class ExamplePage {
+    extendState = () => {
+        return {
+            index: ["a", "b", "c"]
+        }
+    }
+
+    loadData = async function(pageStore, pageDefinition) {
+        console.log(pageStore.index)
+    }
+}
+```
+
+```js
+pageStore.loadData();
+// ["a", "b", "c"]
+```
+
+## Subscriptions
+Additionally, a provided `extendSubscriptions` function will be consumed by Harness-Vue and run as a subscription on the store's actions. This should conform to the [Pinia action subscription syntax](https://pinia.vuejs.org/core-concepts/actions.html#Subscribing-to-actions). This function will be run both "before" and "after" the action, though it will be provided with a variable informing it whether or not it is running before or after.
+
+Arguments:
+* name: the name of the action that fired
+* args: the arguments provided to the action
+* store: the harness-vue page store
+* pageDefinition: the harness-vue page definition
+* `hook`: either `"before"` or `"after"`
+
+As a note, Harness-Vue is already providing subscriptions for filters, charts and loadData via the `beforeSet`/`afterSet` syntax on charts and filters and the `beforeLoadData` and `afterLoadData` syntax.

--- a/package-lock.json
+++ b/package-lock.json
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -269,6 +269,21 @@
         }
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.11.tgz",
+      "integrity": "sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.17.tgz",
@@ -276,6 +291,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -291,6 +307,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -306,6 +323,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -321,6 +339,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -336,6 +355,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -351,6 +371,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -366,6 +387,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -381,6 +403,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -396,6 +419,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -411,6 +435,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -426,6 +451,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -441,6 +467,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -456,6 +483,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -471,6 +499,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -486,6 +515,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -501,6 +531,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -516,6 +547,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -531,6 +563,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -546,6 +579,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -561,6 +595,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -576,6 +611,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -591,6 +627,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -830,6 +867,162 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.4.tgz",
+      "integrity": "sha512-ub/SN3yWqIv5CWiAZPHVS1DloyZsJbtXmX4HxUTIpS0BHm9pW5iYBo2mIZi+hE3AeiTzHz33blwSnhdUo+9NpA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.4.tgz",
+      "integrity": "sha512-ehcBrOR5XTl0W0t2WxfTyHCR/3Cq2jfb+I4W+Ch8Y9b5G+vbAecVv0Fx/J1QKktOrgUYsIKxWAKgIpvw56IFNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.4.tgz",
+      "integrity": "sha512-1fzh1lWExwSTWy8vJPnNbNM02WZDS8AW3McEOb7wW+nPChLKf3WG2aG7fhaUmfX5FKw9zhsF5+MBwArGyNM7NA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.4.tgz",
+      "integrity": "sha512-Gc6cukkF38RcYQ6uPdiXi70JB0f29CwcQ7+r4QpfNpQFVHXRd0DfWFidoGxjSx1DwOETM97JPz1RXL5ISSB0pA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.4.tgz",
+      "integrity": "sha512-g21RTeFzoTl8GxosHbnQZ0/JkuFIB13C3T7Y0HtKzOXmoHhewLbVTFBQZu+z5m9STH6FZ7L/oPgU4Nm5ErN2fw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.4.tgz",
+      "integrity": "sha512-TVYVWD/SYwWzGGnbfTkrNpdE4HON46orgMNHCivlXmlsSGQOx/OHHYiQcMIOx38/GWgwr/po2LBn7wypkWw/Mg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.4.tgz",
+      "integrity": "sha512-XcKvuendwizYYhFxpvQ3xVpzje2HHImzg33wL9zvxtj77HvPStbSGI9czrdbfrf8DGMcNNReH9pVZv8qejAQ5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.4.tgz",
+      "integrity": "sha512-LFHS/8Q+I9YA0yVETyjonMJ3UA+DczeBd/MqNEzsGSTdNvSJa1OJZcSH8GiXLvcizgp9AlHs2walqRcqzjOi3A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.4.tgz",
+      "integrity": "sha512-dIYgo+j1+yfy81i0YVU5KnQrIJZE8ERomx17ReU4GREjGtDW4X+nvkBak2xAUpyqLs4eleDSj3RrV72fQos7zw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.4.tgz",
+      "integrity": "sha512-RoaYxjdHQ5TPjaPrLsfKqR3pakMr3JGqZ+jZM0zP2IkDtsGa4CqYaWSfQmZVgFUCgLrTnzX+cnHS3nfl+kB6ZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.4.tgz",
+      "integrity": "sha512-T8Q3XHV+Jjf5e49B4EAaLKV74BbX7/qYBRQ8Wop/+TyyU0k+vSjiLVSHNWdVd1goMjZcbhDmYZUYW5RFqkBNHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.4.tgz",
+      "integrity": "sha512-z+JQ7JirDUHAsMecVydnBPWLwJjbppU+7LZjffGf+Jvrxq+dVjIE7By163Sc9DKc3ADSU50qPVw0KonBS+a+HQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.4.tgz",
+      "integrity": "sha512-LfdGXCV9rdEify1oxlN9eamvDSjv9md9ZVMAbNHA87xqIfFCxImxan9qZ8+Un54iK2nnqPlbnSi4R54ONtbWBw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.2.tgz",
@@ -866,6 +1059,11 @@
         "@types/chai": "*"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -899,9 +1097,9 @@
       "devOptional": true
     },
     "node_modules/@types/web-bluetooth": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.18.tgz",
-      "integrity": "sha512-v/ZHEj9xh82usl8LMR3GarzFY1IrbXJw5L4QfQhokjRV91q+SelFqxQWSep1ucXEZ22+dSTwLFkXeur25sPIbw=="
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "4.2.3",
@@ -1077,9 +1275,9 @@
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
-      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.1.tgz",
+      "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA=="
     },
     "node_modules/@vue/eslint-config-prettier": {
       "version": "8.0.0",
@@ -1171,13 +1369,13 @@
       }
     },
     "node_modules/@vueuse/core": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.5.0.tgz",
-      "integrity": "sha512-z/tI2eSvxwLRjOhDm0h/SXAjNm8N5ld6/SC/JQs6o6kpJ6Ya50LnEL8g5hoYu005i28L0zqB5L5yAl8Jl26K3A==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.7.1.tgz",
+      "integrity": "sha512-74mWHlaesJSWGp1ihg76vAnfVq9NTv1YT0SYhAQ6zwFNdBkkP+CKKJmVOEHcdSnLXCXYiL5e7MaewblfiYLP7g==",
       "dependencies": {
-        "@types/web-bluetooth": "^0.0.18",
-        "@vueuse/metadata": "10.5.0",
-        "@vueuse/shared": "10.5.0",
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.7.1",
+        "@vueuse/shared": "10.7.1",
         "vue-demi": ">=0.14.6"
       },
       "funding": {
@@ -1210,12 +1408,12 @@
       }
     },
     "node_modules/@vueuse/integrations": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.5.0.tgz",
-      "integrity": "sha512-fm5sXLCK0Ww3rRnzqnCQRmfjDURaI4xMsx+T+cec0ngQqHx/JgUtm8G0vRjwtonIeTBsH1Q8L3SucE+7K7upJQ==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.7.1.tgz",
+      "integrity": "sha512-cKo5LEeKVHdBRBtMTOrDPdR0YNtrmN9IBfdcnY2P3m5LHVrsD0xiHUtAH1WKjHQRIErZG6rJUa6GA4tWZt89Og==",
       "dependencies": {
-        "@vueuse/core": "10.5.0",
-        "@vueuse/shared": "10.5.0",
+        "@vueuse/core": "10.7.1",
+        "@vueuse/shared": "10.7.1",
         "vue-demi": ">=0.14.6"
       },
       "funding": {
@@ -1300,17 +1498,17 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.5.0.tgz",
-      "integrity": "sha512-fEbElR+MaIYyCkeM0SzWkdoMtOpIwO72x8WsZHRE7IggiOlILttqttM69AS13nrDxosnDBYdyy3C5mR1LCxHsw==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.7.1.tgz",
+      "integrity": "sha512-jX8MbX5UX067DYVsbtrmKn6eG6KMcXxLRLlurGkZku5ZYT3vxgBjui2zajvUZ18QLIjrgBkFRsu7CqTAg18QFw==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.5.0.tgz",
-      "integrity": "sha512-18iyxbbHYLst9MqU1X1QNdMHIjks6wC7XTVf0KNOv5es/Ms6gjVFCAAWTVP2JStuGqydg3DT+ExpFORUEi9yhg==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.7.1.tgz",
+      "integrity": "sha512-v0jbRR31LSgRY/C5i5X279A/WQjD6/JsMzGa+eqt658oJ75IvQXAeONmwvEMrvJQKnRElq/frzBR7fhmWY5uLw==",
       "dependencies": {
         "vue-demi": ">=0.14.6"
       },
@@ -1463,11 +1661,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/ansi-sequence-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -1951,9 +2144,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/data-urls": {
       "version": "4.0.0",
@@ -2191,6 +2384,7 @@
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.17.tgz",
       "integrity": "sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -2664,9 +2858,9 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.3.tgz",
-      "integrity": "sha512-7UsT/eSJcTPF0aZp73u7hBRTABz26knRRTJfoTGFCQD5mUImLIIOwWWCrtoQdmWa7dykBi6H+Cp5i3S/kvsMeA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
+      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -3349,7 +3543,8 @@
     "node_modules/jsonc-parser": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
     },
     "node_modules/klaw": {
       "version": "3.0.0",
@@ -3467,9 +3662,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
-      "integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
@@ -3629,9 +3824,9 @@
       }
     },
     "node_modules/minisearch": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.1.0.tgz",
-      "integrity": "sha512-PNxA/X8pWk+TiqPbsoIYH0GQ5Di7m6326/lwU/S4mlo4wGQddIcf/V//1f9TB0V4j59b57b+HZxt8h3iMROGvg=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.3.0.tgz",
+      "integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -3670,9 +3865,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -4019,9 +4214,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4037,7 +4232,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -4356,6 +4551,7 @@
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
       "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -4560,15 +4756,25 @@
         "node": ">=8"
       }
     },
-    "node_modules/shiki": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.4.tgz",
-      "integrity": "sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==",
+    "node_modules/shikiji": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.18.tgz",
+      "integrity": "sha512-/tFMIdV7UQklzN13VjF0/XFzmii6C606Jc878hNezvB8ZR8FG8FW9j0I4J9EJre0owlnPntgLVPpHqy27Gs+DQ==",
       "dependencies": {
-        "ansi-sequence-parser": "^1.1.0",
-        "jsonc-parser": "^3.2.0",
-        "vscode-oniguruma": "^1.7.0",
-        "vscode-textmate": "^8.0.0"
+        "shikiji-core": "0.9.18"
+      }
+    },
+    "node_modules/shikiji-core": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/shikiji-core/-/shikiji-core-0.9.18.tgz",
+      "integrity": "sha512-PKTXptbrp/WEDjNHV8OFG9KkfhmR0pSd161kzlDDlgQ0HXAnqJYNDSjqsy1CYZMx5bSvLMy42yJj9oFTqmkNTQ=="
+    },
+    "node_modules/shikiji-transformers": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.18.tgz",
+      "integrity": "sha512-lvKVfgx1ETDqUNxqiUn+whlnjQiunsAg76DOpzjjxkHE/bLcwa+jrghcMxQhui86SLR1tzCdM4Imh+RxW0LI2Q==",
+      "dependencies": {
+        "shikiji": "0.9.18"
       }
     },
     "node_modules/siginfo": {
@@ -5088,6 +5294,7 @@
       "version": "4.4.11",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
       "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
+      "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -5162,29 +5369,32 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.20.tgz",
-      "integrity": "sha512-CykMUJ8JLxLcGWek0ew3wln4RYbsOd1+0YzXITTpajggpynm2S331TNkJVOkHrMRc6GYe3y4pS40GfgcW0ZwAw==",
+      "version": "1.0.0-rc.36",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.36.tgz",
+      "integrity": "sha512-2z4dpM9PplN/yvTifhavOIAazlCR6OJ5PvLoRbc+7LdcFeIlCsuDGENLX4HjMW18jQZF5/j7++PNqdBfeazxUA==",
       "dependencies": {
         "@docsearch/css": "^3.5.2",
         "@docsearch/js": "^3.5.2",
-        "@types/markdown-it": "^13.0.1",
-        "@vue/devtools-api": "^6.5.0",
-        "@vueuse/core": "^10.4.1",
-        "@vueuse/integrations": "^10.4.1",
-        "focus-trap": "^7.5.2",
+        "@types/markdown-it": "^13.0.7",
+        "@vitejs/plugin-vue": "^5.0.2",
+        "@vue/devtools-api": "^6.5.1",
+        "@vueuse/core": "^10.7.1",
+        "@vueuse/integrations": "^10.7.1",
+        "focus-trap": "^7.5.4",
         "mark.js": "8.11.1",
-        "minisearch": "^6.1.0",
-        "shiki": "^0.14.4",
-        "vite": "^4.4.9",
-        "vue": "^3.3.4"
+        "minisearch": "^6.3.0",
+        "shikiji": "^0.9.17",
+        "shikiji-core": "^0.9.17",
+        "shikiji-transformers": "^0.9.17",
+        "vite": "^5.0.11",
+        "vue": "^3.4.5"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"
       },
       "peerDependencies": {
         "markdown-it-mathjax3": "^4.3.2",
-        "postcss": "^8.4.30"
+        "postcss": "^8.4.33"
       },
       "peerDependenciesMeta": {
         "markdown-it-mathjax3": {
@@ -5195,13 +5405,598 @@
         }
       }
     },
+    "node_modules/vitepress/node_modules/@esbuild/android-arm": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.11.tgz",
+      "integrity": "sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/android-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.11.tgz",
+      "integrity": "sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/android-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.11.tgz",
+      "integrity": "sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.11.tgz",
+      "integrity": "sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.11.tgz",
+      "integrity": "sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.11.tgz",
+      "integrity": "sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.11.tgz",
+      "integrity": "sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-arm": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.11.tgz",
+      "integrity": "sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.11.tgz",
+      "integrity": "sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.11.tgz",
+      "integrity": "sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.11.tgz",
+      "integrity": "sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.11.tgz",
+      "integrity": "sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.11.tgz",
+      "integrity": "sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.11.tgz",
+      "integrity": "sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.11.tgz",
+      "integrity": "sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.11.tgz",
+      "integrity": "sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.11.tgz",
+      "integrity": "sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.11.tgz",
+      "integrity": "sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.11.tgz",
+      "integrity": "sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.11.tgz",
+      "integrity": "sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.11.tgz",
+      "integrity": "sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-x64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.11.tgz",
+      "integrity": "sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/vitepress/node_modules/@types/markdown-it": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.2.tgz",
-      "integrity": "sha512-Tla7hH9oeXHOlJyBFdoqV61xWE9FZf/y2g+gFVwQ2vE1/eBzjUno5JCd3Hdb5oATve5OF6xNjZ/4VIZhVVx+hA==",
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.7.tgz",
+      "integrity": "sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==",
       "dependencies": {
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vitejs/plugin-vue": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.2.tgz",
+      "integrity": "sha512-kEjJHrLb5ePBvjD0SPZwJlw1QTRcjjCA9sB5VyfonoXVBxTS7TMnqL6EkLt1Eu61RDeiuZ/WN9Hf6PxXhPI2uA==",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/compiler-core": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.7.tgz",
+      "integrity": "sha512-hhCaE3pTMrlIJK7M/o3Xf7HV8+JoNTGOQ/coWS+V+pH6QFFyqtoXqQzpqsNp7UK17xYKua/MBiKj4e1vgZOBYw==",
+      "dependencies": {
+        "@babel/parser": "^7.23.6",
+        "@vue/shared": "3.4.7",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/compiler-dom": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.7.tgz",
+      "integrity": "sha512-qDKBAIurCTub4n/6jDYkXwgsFuriqqmmLrIq1N2QDfYJA/mwiwvxi09OGn28g+uDdERX9NaKDLji0oTjE3sScg==",
+      "dependencies": {
+        "@vue/compiler-core": "3.4.7",
+        "@vue/shared": "3.4.7"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/compiler-sfc": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.7.tgz",
+      "integrity": "sha512-Gec6CLkReVswDYjQFq79O5rktri4R7TsD/VPCiUoJw40JhNNxaNJJa8mrQrWoJluW4ETy6QN0NUyC/JO77OCOw==",
+      "dependencies": {
+        "@babel/parser": "^7.23.6",
+        "@vue/compiler-core": "3.4.7",
+        "@vue/compiler-dom": "3.4.7",
+        "@vue/compiler-ssr": "3.4.7",
+        "@vue/shared": "3.4.7",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.32",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/compiler-ssr": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.7.tgz",
+      "integrity": "sha512-PvYeSOvnCkST5mGS0TLwEn5w+4GavtEn6adcq8AspbHaIr+mId5hp7cG3ASy3iy8b+LuXEG2/QaV/nj5BQ/Aww==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.7",
+        "@vue/shared": "3.4.7"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/reactivity": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.7.tgz",
+      "integrity": "sha512-F539DO0ogH0+L8F9Pnw7cjqibcmSOh5UTk16u5f4MKQ8fraqepI9zdh+sozPX6VmEHOcjo8qw3Or9ZcFFw4SZA==",
+      "dependencies": {
+        "@vue/shared": "3.4.7"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/runtime-core": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.7.tgz",
+      "integrity": "sha512-QMMsWRQaD3BpGyjjChthpl4Mji4Fjx1qfdufsXlDkKU3HV+hWNor2z+29F+E1MmVcP0ZfRZUfqYgtsQoL7IGwQ==",
+      "dependencies": {
+        "@vue/reactivity": "3.4.7",
+        "@vue/shared": "3.4.7"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/runtime-dom": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.7.tgz",
+      "integrity": "sha512-XwegyUY1rw8zxsX1Z36vwYcqo+uOgih5ti7y9vx+pPFhNdSQmN4LqK2RmSeAJG1oKV8NqSUmjpv92f/x6h0SeQ==",
+      "dependencies": {
+        "@vue/runtime-core": "3.4.7",
+        "@vue/shared": "3.4.7",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/server-renderer": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.7.tgz",
+      "integrity": "sha512-3bWnYLEkLLhkDWqvNk7IvbQD4UcxvFKxELBiOO2iG3m6AniFIsBWfHOO5tLVQnjdWkODu4rq0GipmfEenVAK5Q==",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.4.7",
+        "@vue/shared": "3.4.7"
+      },
+      "peerDependencies": {
+        "vue": "3.4.7"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vue/shared": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.7.tgz",
+      "integrity": "sha512-G+i4glX1dMJk88sbJEcQEGWRQnVm9eIY7CcQbO5dpdsD9SF8jka3Mr5OqZYGjczGN1+D6EUwdu6phcmcx9iuPA=="
+    },
+    "node_modules/vitepress/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/vitepress/node_modules/esbuild": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.11.tgz",
+      "integrity": "sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.11",
+        "@esbuild/android-arm": "0.19.11",
+        "@esbuild/android-arm64": "0.19.11",
+        "@esbuild/android-x64": "0.19.11",
+        "@esbuild/darwin-arm64": "0.19.11",
+        "@esbuild/darwin-x64": "0.19.11",
+        "@esbuild/freebsd-arm64": "0.19.11",
+        "@esbuild/freebsd-x64": "0.19.11",
+        "@esbuild/linux-arm": "0.19.11",
+        "@esbuild/linux-arm64": "0.19.11",
+        "@esbuild/linux-ia32": "0.19.11",
+        "@esbuild/linux-loong64": "0.19.11",
+        "@esbuild/linux-mips64el": "0.19.11",
+        "@esbuild/linux-ppc64": "0.19.11",
+        "@esbuild/linux-riscv64": "0.19.11",
+        "@esbuild/linux-s390x": "0.19.11",
+        "@esbuild/linux-x64": "0.19.11",
+        "@esbuild/netbsd-x64": "0.19.11",
+        "@esbuild/openbsd-x64": "0.19.11",
+        "@esbuild/sunos-x64": "0.19.11",
+        "@esbuild/win32-arm64": "0.19.11",
+        "@esbuild/win32-ia32": "0.19.11",
+        "@esbuild/win32-x64": "0.19.11"
+      }
+    },
+    "node_modules/vitepress/node_modules/rollup": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.4.tgz",
+      "integrity": "sha512-2ztU7pY/lrQyXSCnnoU4ICjT/tCG9cdH3/G25ERqE3Lst6vl2BCM5hL2Nw+sslAvAf+ccKsAq1SkKQALyqhR7g==",
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.9.4",
+        "@rollup/rollup-android-arm64": "4.9.4",
+        "@rollup/rollup-darwin-arm64": "4.9.4",
+        "@rollup/rollup-darwin-x64": "4.9.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.9.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.4",
+        "@rollup/rollup-linux-arm64-musl": "4.9.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.9.4",
+        "@rollup/rollup-linux-x64-gnu": "4.9.4",
+        "@rollup/rollup-linux-x64-musl": "4.9.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.9.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.9.4",
+        "@rollup/rollup-win32-x64-msvc": "4.9.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vitepress/node_modules/vite": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
+      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+      "dependencies": {
+        "esbuild": "^0.19.3",
+        "postcss": "^8.4.32",
+        "rollup": "^4.2.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress/node_modules/vue": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.7.tgz",
+      "integrity": "sha512-4urmkWpudekq0CPNMO7p6mBGa9qmTXwJMO2r6CT4EzIJVG7WoSReiysiNb7OSi/WI113oX0Srn9Rz1k/DCXKFQ==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.7",
+        "@vue/compiler-sfc": "3.4.7",
+        "@vue/runtime-dom": "3.4.7",
+        "@vue/server-renderer": "3.4.7",
+        "@vue/shared": "3.4.7"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vitest": {
@@ -5280,16 +6075,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
-    },
-    "node_modules/vscode-textmate": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
     },
     "node_modules/vue": {
       "version": "3.3.4",
@@ -5740,9 +6525,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q=="
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ=="
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -5775,136 +6560,164 @@
         "algoliasearch": "^4.19.1"
       }
     },
+    "@esbuild/aix-ppc64": {
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.11.tgz",
+      "integrity": "sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==",
+      "optional": true
+    },
     "@esbuild/android-arm": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.17.tgz",
       "integrity": "sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/android-arm64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.17.tgz",
       "integrity": "sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/android-x64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.17.tgz",
       "integrity": "sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/darwin-arm64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.17.tgz",
       "integrity": "sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/darwin-x64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.17.tgz",
       "integrity": "sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-arm64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.17.tgz",
       "integrity": "sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-x64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.17.tgz",
       "integrity": "sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.17.tgz",
       "integrity": "sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.17.tgz",
       "integrity": "sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/linux-ia32": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.17.tgz",
       "integrity": "sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/linux-loong64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.17.tgz",
       "integrity": "sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/linux-mips64el": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.17.tgz",
       "integrity": "sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/linux-ppc64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.17.tgz",
       "integrity": "sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/linux-riscv64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.17.tgz",
       "integrity": "sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/linux-s390x": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.17.tgz",
       "integrity": "sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/linux-x64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.17.tgz",
       "integrity": "sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/netbsd-x64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.17.tgz",
       "integrity": "sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/openbsd-x64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.17.tgz",
       "integrity": "sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/sunos-x64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.17.tgz",
       "integrity": "sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/win32-arm64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.17.tgz",
       "integrity": "sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/win32-ia32": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.17.tgz",
       "integrity": "sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/win32-x64": {
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.17.tgz",
       "integrity": "sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==",
+      "dev": true,
       "optional": true
     },
     "@eslint-community/eslint-utils": {
@@ -6077,6 +6890,84 @@
         "tslib": "^2.6.0"
       }
     },
+    "@rollup/rollup-android-arm-eabi": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.4.tgz",
+      "integrity": "sha512-ub/SN3yWqIv5CWiAZPHVS1DloyZsJbtXmX4HxUTIpS0BHm9pW5iYBo2mIZi+hE3AeiTzHz33blwSnhdUo+9NpA==",
+      "optional": true
+    },
+    "@rollup/rollup-android-arm64": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.4.tgz",
+      "integrity": "sha512-ehcBrOR5XTl0W0t2WxfTyHCR/3Cq2jfb+I4W+Ch8Y9b5G+vbAecVv0Fx/J1QKktOrgUYsIKxWAKgIpvw56IFNA==",
+      "optional": true
+    },
+    "@rollup/rollup-darwin-arm64": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.4.tgz",
+      "integrity": "sha512-1fzh1lWExwSTWy8vJPnNbNM02WZDS8AW3McEOb7wW+nPChLKf3WG2aG7fhaUmfX5FKw9zhsF5+MBwArGyNM7NA==",
+      "optional": true
+    },
+    "@rollup/rollup-darwin-x64": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.4.tgz",
+      "integrity": "sha512-Gc6cukkF38RcYQ6uPdiXi70JB0f29CwcQ7+r4QpfNpQFVHXRd0DfWFidoGxjSx1DwOETM97JPz1RXL5ISSB0pA==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.4.tgz",
+      "integrity": "sha512-g21RTeFzoTl8GxosHbnQZ0/JkuFIB13C3T7Y0HtKzOXmoHhewLbVTFBQZu+z5m9STH6FZ7L/oPgU4Nm5ErN2fw==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.4.tgz",
+      "integrity": "sha512-TVYVWD/SYwWzGGnbfTkrNpdE4HON46orgMNHCivlXmlsSGQOx/OHHYiQcMIOx38/GWgwr/po2LBn7wypkWw/Mg==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-musl": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.4.tgz",
+      "integrity": "sha512-XcKvuendwizYYhFxpvQ3xVpzje2HHImzg33wL9zvxtj77HvPStbSGI9czrdbfrf8DGMcNNReH9pVZv8qejAQ5A==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.4.tgz",
+      "integrity": "sha512-LFHS/8Q+I9YA0yVETyjonMJ3UA+DczeBd/MqNEzsGSTdNvSJa1OJZcSH8GiXLvcizgp9AlHs2walqRcqzjOi3A==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-gnu": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.4.tgz",
+      "integrity": "sha512-dIYgo+j1+yfy81i0YVU5KnQrIJZE8ERomx17ReU4GREjGtDW4X+nvkBak2xAUpyqLs4eleDSj3RrV72fQos7zw==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-musl": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.4.tgz",
+      "integrity": "sha512-RoaYxjdHQ5TPjaPrLsfKqR3pakMr3JGqZ+jZM0zP2IkDtsGa4CqYaWSfQmZVgFUCgLrTnzX+cnHS3nfl+kB6ZQ==",
+      "optional": true
+    },
+    "@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.4.tgz",
+      "integrity": "sha512-T8Q3XHV+Jjf5e49B4EAaLKV74BbX7/qYBRQ8Wop/+TyyU0k+vSjiLVSHNWdVd1goMjZcbhDmYZUYW5RFqkBNHQ==",
+      "optional": true
+    },
+    "@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.4.tgz",
+      "integrity": "sha512-z+JQ7JirDUHAsMecVydnBPWLwJjbppU+7LZjffGf+Jvrxq+dVjIE7By163Sc9DKc3ADSU50qPVw0KonBS+a+HQ==",
+      "optional": true
+    },
+    "@rollup/rollup-win32-x64-msvc": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.4.tgz",
+      "integrity": "sha512-LfdGXCV9rdEify1oxlN9eamvDSjv9md9ZVMAbNHA87xqIfFCxImxan9qZ8+Un54iK2nnqPlbnSi4R54ONtbWBw==",
+      "optional": true
+    },
     "@rushstack/eslint-patch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.2.tgz",
@@ -6109,6 +7000,11 @@
       "requires": {
         "@types/chai": "*"
       }
+    },
+    "@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -6143,9 +7039,9 @@
       "devOptional": true
     },
     "@types/web-bluetooth": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.18.tgz",
-      "integrity": "sha512-v/ZHEj9xh82usl8LMR3GarzFY1IrbXJw5L4QfQhokjRV91q+SelFqxQWSep1ucXEZ22+dSTwLFkXeur25sPIbw=="
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
     },
     "@vitejs/plugin-vue": {
       "version": "4.2.3",
@@ -6284,9 +7180,9 @@
       }
     },
     "@vue/devtools-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
-      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.1.tgz",
+      "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA=="
     },
     "@vue/eslint-config-prettier": {
       "version": "8.0.0",
@@ -6362,13 +7258,13 @@
       }
     },
     "@vueuse/core": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.5.0.tgz",
-      "integrity": "sha512-z/tI2eSvxwLRjOhDm0h/SXAjNm8N5ld6/SC/JQs6o6kpJ6Ya50LnEL8g5hoYu005i28L0zqB5L5yAl8Jl26K3A==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.7.1.tgz",
+      "integrity": "sha512-74mWHlaesJSWGp1ihg76vAnfVq9NTv1YT0SYhAQ6zwFNdBkkP+CKKJmVOEHcdSnLXCXYiL5e7MaewblfiYLP7g==",
       "requires": {
-        "@types/web-bluetooth": "^0.0.18",
-        "@vueuse/metadata": "10.5.0",
-        "@vueuse/shared": "10.5.0",
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.7.1",
+        "@vueuse/shared": "10.7.1",
         "vue-demi": ">=0.14.6"
       },
       "dependencies": {
@@ -6381,12 +7277,12 @@
       }
     },
     "@vueuse/integrations": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.5.0.tgz",
-      "integrity": "sha512-fm5sXLCK0Ww3rRnzqnCQRmfjDURaI4xMsx+T+cec0ngQqHx/JgUtm8G0vRjwtonIeTBsH1Q8L3SucE+7K7upJQ==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.7.1.tgz",
+      "integrity": "sha512-cKo5LEeKVHdBRBtMTOrDPdR0YNtrmN9IBfdcnY2P3m5LHVrsD0xiHUtAH1WKjHQRIErZG6rJUa6GA4tWZt89Og==",
       "requires": {
-        "@vueuse/core": "10.5.0",
-        "@vueuse/shared": "10.5.0",
+        "@vueuse/core": "10.7.1",
+        "@vueuse/shared": "10.7.1",
         "vue-demi": ">=0.14.6"
       },
       "dependencies": {
@@ -6399,14 +7295,14 @@
       }
     },
     "@vueuse/metadata": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.5.0.tgz",
-      "integrity": "sha512-fEbElR+MaIYyCkeM0SzWkdoMtOpIwO72x8WsZHRE7IggiOlILttqttM69AS13nrDxosnDBYdyy3C5mR1LCxHsw=="
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.7.1.tgz",
+      "integrity": "sha512-jX8MbX5UX067DYVsbtrmKn6eG6KMcXxLRLlurGkZku5ZYT3vxgBjui2zajvUZ18QLIjrgBkFRsu7CqTAg18QFw=="
     },
     "@vueuse/shared": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.5.0.tgz",
-      "integrity": "sha512-18iyxbbHYLst9MqU1X1QNdMHIjks6wC7XTVf0KNOv5es/Ms6gjVFCAAWTVP2JStuGqydg3DT+ExpFORUEi9yhg==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.7.1.tgz",
+      "integrity": "sha512-v0jbRR31LSgRY/C5i5X279A/WQjD6/JsMzGa+eqt658oJ75IvQXAeONmwvEMrvJQKnRElq/frzBR7fhmWY5uLw==",
       "requires": {
         "vue-demi": ">=0.14.6"
       },
@@ -6514,11 +7410,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
-    },
-    "ansi-sequence-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -6901,9 +7792,9 @@
       }
     },
     "csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "data-urls": {
       "version": "4.0.0",
@@ -7078,6 +7969,7 @@
       "version": "0.18.17",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.17.tgz",
       "integrity": "sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==",
+      "dev": true,
       "requires": {
         "@esbuild/android-arm": "0.18.17",
         "@esbuild/android-arm64": "0.18.17",
@@ -7427,9 +8319,9 @@
       "dev": true
     },
     "focus-trap": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.3.tgz",
-      "integrity": "sha512-7UsT/eSJcTPF0aZp73u7hBRTABz26knRRTJfoTGFCQD5mUImLIIOwWWCrtoQdmWa7dykBi6H+Cp5i3S/kvsMeA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
+      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
       "requires": {
         "tabbable": "^6.2.0"
       }
@@ -7931,7 +8823,8 @@
     "jsonc-parser": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
     },
     "klaw": {
       "version": "3.0.0",
@@ -8031,9 +8924,9 @@
       }
     },
     "magic-string": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
-      "integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
@@ -8150,9 +9043,9 @@
       "dev": true
     },
     "minisearch": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.1.0.tgz",
-      "integrity": "sha512-PNxA/X8pWk+TiqPbsoIYH0GQ5Di7m6326/lwU/S4mlo4wGQddIcf/V//1f9TB0V4j59b57b+HZxt8h3iMROGvg=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.3.0.tgz",
+      "integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ=="
     },
     "mkdirp": {
       "version": "1.0.4",
@@ -8185,9 +9078,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -8412,11 +9305,11 @@
       }
     },
     "postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "requires": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -8646,6 +9539,7 @@
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
       "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -8780,15 +9674,25 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
-    "shiki": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.4.tgz",
-      "integrity": "sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==",
+    "shikiji": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.18.tgz",
+      "integrity": "sha512-/tFMIdV7UQklzN13VjF0/XFzmii6C606Jc878hNezvB8ZR8FG8FW9j0I4J9EJre0owlnPntgLVPpHqy27Gs+DQ==",
       "requires": {
-        "ansi-sequence-parser": "^1.1.0",
-        "jsonc-parser": "^3.2.0",
-        "vscode-oniguruma": "^1.7.0",
-        "vscode-textmate": "^8.0.0"
+        "shikiji-core": "0.9.18"
+      }
+    },
+    "shikiji-core": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/shikiji-core/-/shikiji-core-0.9.18.tgz",
+      "integrity": "sha512-PKTXptbrp/WEDjNHV8OFG9KkfhmR0pSd161kzlDDlgQ0HXAnqJYNDSjqsy1CYZMx5bSvLMy42yJj9oFTqmkNTQ=="
+    },
+    "shikiji-transformers": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.18.tgz",
+      "integrity": "sha512-lvKVfgx1ETDqUNxqiUn+whlnjQiunsAg76DOpzjjxkHE/bLcwa+jrghcMxQhui86SLR1tzCdM4Imh+RxW0LI2Q==",
+      "requires": {
+        "shikiji": "0.9.18"
       }
     },
     "siginfo": {
@@ -9195,6 +10099,7 @@
       "version": "4.4.11",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
       "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
+      "dev": true,
       "requires": {
         "esbuild": "^0.18.10",
         "fsevents": "~2.3.2",
@@ -9217,31 +10122,339 @@
       }
     },
     "vitepress": {
-      "version": "1.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.20.tgz",
-      "integrity": "sha512-CykMUJ8JLxLcGWek0ew3wln4RYbsOd1+0YzXITTpajggpynm2S331TNkJVOkHrMRc6GYe3y4pS40GfgcW0ZwAw==",
+      "version": "1.0.0-rc.36",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.36.tgz",
+      "integrity": "sha512-2z4dpM9PplN/yvTifhavOIAazlCR6OJ5PvLoRbc+7LdcFeIlCsuDGENLX4HjMW18jQZF5/j7++PNqdBfeazxUA==",
       "requires": {
         "@docsearch/css": "^3.5.2",
         "@docsearch/js": "^3.5.2",
-        "@types/markdown-it": "^13.0.1",
-        "@vue/devtools-api": "^6.5.0",
-        "@vueuse/core": "^10.4.1",
-        "@vueuse/integrations": "^10.4.1",
-        "focus-trap": "^7.5.2",
+        "@types/markdown-it": "^13.0.7",
+        "@vitejs/plugin-vue": "^5.0.2",
+        "@vue/devtools-api": "^6.5.1",
+        "@vueuse/core": "^10.7.1",
+        "@vueuse/integrations": "^10.7.1",
+        "focus-trap": "^7.5.4",
         "mark.js": "8.11.1",
-        "minisearch": "^6.1.0",
-        "shiki": "^0.14.4",
-        "vite": "^4.4.9",
-        "vue": "^3.3.4"
+        "minisearch": "^6.3.0",
+        "shikiji": "^0.9.17",
+        "shikiji-core": "^0.9.17",
+        "shikiji-transformers": "^0.9.17",
+        "vite": "^5.0.11",
+        "vue": "^3.4.5"
       },
       "dependencies": {
+        "@esbuild/android-arm": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.11.tgz",
+          "integrity": "sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==",
+          "optional": true
+        },
+        "@esbuild/android-arm64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.11.tgz",
+          "integrity": "sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==",
+          "optional": true
+        },
+        "@esbuild/android-x64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.11.tgz",
+          "integrity": "sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==",
+          "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.11.tgz",
+          "integrity": "sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==",
+          "optional": true
+        },
+        "@esbuild/darwin-x64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.11.tgz",
+          "integrity": "sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==",
+          "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.11.tgz",
+          "integrity": "sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==",
+          "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.11.tgz",
+          "integrity": "sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==",
+          "optional": true
+        },
+        "@esbuild/linux-arm": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.11.tgz",
+          "integrity": "sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==",
+          "optional": true
+        },
+        "@esbuild/linux-arm64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.11.tgz",
+          "integrity": "sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==",
+          "optional": true
+        },
+        "@esbuild/linux-ia32": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.11.tgz",
+          "integrity": "sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==",
+          "optional": true
+        },
+        "@esbuild/linux-loong64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.11.tgz",
+          "integrity": "sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==",
+          "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.11.tgz",
+          "integrity": "sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==",
+          "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.11.tgz",
+          "integrity": "sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==",
+          "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.11.tgz",
+          "integrity": "sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==",
+          "optional": true
+        },
+        "@esbuild/linux-s390x": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.11.tgz",
+          "integrity": "sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==",
+          "optional": true
+        },
+        "@esbuild/linux-x64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.11.tgz",
+          "integrity": "sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==",
+          "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.11.tgz",
+          "integrity": "sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==",
+          "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.11.tgz",
+          "integrity": "sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==",
+          "optional": true
+        },
+        "@esbuild/sunos-x64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.11.tgz",
+          "integrity": "sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==",
+          "optional": true
+        },
+        "@esbuild/win32-arm64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.11.tgz",
+          "integrity": "sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==",
+          "optional": true
+        },
+        "@esbuild/win32-ia32": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.11.tgz",
+          "integrity": "sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==",
+          "optional": true
+        },
+        "@esbuild/win32-x64": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.11.tgz",
+          "integrity": "sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==",
+          "optional": true
+        },
         "@types/markdown-it": {
-          "version": "13.0.2",
-          "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.2.tgz",
-          "integrity": "sha512-Tla7hH9oeXHOlJyBFdoqV61xWE9FZf/y2g+gFVwQ2vE1/eBzjUno5JCd3Hdb5oATve5OF6xNjZ/4VIZhVVx+hA==",
+          "version": "13.0.7",
+          "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.7.tgz",
+          "integrity": "sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==",
           "requires": {
             "@types/linkify-it": "*",
             "@types/mdurl": "*"
+          }
+        },
+        "@vitejs/plugin-vue": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.2.tgz",
+          "integrity": "sha512-kEjJHrLb5ePBvjD0SPZwJlw1QTRcjjCA9sB5VyfonoXVBxTS7TMnqL6EkLt1Eu61RDeiuZ/WN9Hf6PxXhPI2uA==",
+          "requires": {}
+        },
+        "@vue/compiler-core": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.7.tgz",
+          "integrity": "sha512-hhCaE3pTMrlIJK7M/o3Xf7HV8+JoNTGOQ/coWS+V+pH6QFFyqtoXqQzpqsNp7UK17xYKua/MBiKj4e1vgZOBYw==",
+          "requires": {
+            "@babel/parser": "^7.23.6",
+            "@vue/shared": "3.4.7",
+            "entities": "^4.5.0",
+            "estree-walker": "^2.0.2",
+            "source-map-js": "^1.0.2"
+          }
+        },
+        "@vue/compiler-dom": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.7.tgz",
+          "integrity": "sha512-qDKBAIurCTub4n/6jDYkXwgsFuriqqmmLrIq1N2QDfYJA/mwiwvxi09OGn28g+uDdERX9NaKDLji0oTjE3sScg==",
+          "requires": {
+            "@vue/compiler-core": "3.4.7",
+            "@vue/shared": "3.4.7"
+          }
+        },
+        "@vue/compiler-sfc": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.7.tgz",
+          "integrity": "sha512-Gec6CLkReVswDYjQFq79O5rktri4R7TsD/VPCiUoJw40JhNNxaNJJa8mrQrWoJluW4ETy6QN0NUyC/JO77OCOw==",
+          "requires": {
+            "@babel/parser": "^7.23.6",
+            "@vue/compiler-core": "3.4.7",
+            "@vue/compiler-dom": "3.4.7",
+            "@vue/compiler-ssr": "3.4.7",
+            "@vue/shared": "3.4.7",
+            "estree-walker": "^2.0.2",
+            "magic-string": "^0.30.5",
+            "postcss": "^8.4.32",
+            "source-map-js": "^1.0.2"
+          }
+        },
+        "@vue/compiler-ssr": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.7.tgz",
+          "integrity": "sha512-PvYeSOvnCkST5mGS0TLwEn5w+4GavtEn6adcq8AspbHaIr+mId5hp7cG3ASy3iy8b+LuXEG2/QaV/nj5BQ/Aww==",
+          "requires": {
+            "@vue/compiler-dom": "3.4.7",
+            "@vue/shared": "3.4.7"
+          }
+        },
+        "@vue/reactivity": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.7.tgz",
+          "integrity": "sha512-F539DO0ogH0+L8F9Pnw7cjqibcmSOh5UTk16u5f4MKQ8fraqepI9zdh+sozPX6VmEHOcjo8qw3Or9ZcFFw4SZA==",
+          "requires": {
+            "@vue/shared": "3.4.7"
+          }
+        },
+        "@vue/runtime-core": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.7.tgz",
+          "integrity": "sha512-QMMsWRQaD3BpGyjjChthpl4Mji4Fjx1qfdufsXlDkKU3HV+hWNor2z+29F+E1MmVcP0ZfRZUfqYgtsQoL7IGwQ==",
+          "requires": {
+            "@vue/reactivity": "3.4.7",
+            "@vue/shared": "3.4.7"
+          }
+        },
+        "@vue/runtime-dom": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.7.tgz",
+          "integrity": "sha512-XwegyUY1rw8zxsX1Z36vwYcqo+uOgih5ti7y9vx+pPFhNdSQmN4LqK2RmSeAJG1oKV8NqSUmjpv92f/x6h0SeQ==",
+          "requires": {
+            "@vue/runtime-core": "3.4.7",
+            "@vue/shared": "3.4.7",
+            "csstype": "^3.1.3"
+          }
+        },
+        "@vue/server-renderer": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.7.tgz",
+          "integrity": "sha512-3bWnYLEkLLhkDWqvNk7IvbQD4UcxvFKxELBiOO2iG3m6AniFIsBWfHOO5tLVQnjdWkODu4rq0GipmfEenVAK5Q==",
+          "requires": {
+            "@vue/compiler-ssr": "3.4.7",
+            "@vue/shared": "3.4.7"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.7.tgz",
+          "integrity": "sha512-G+i4glX1dMJk88sbJEcQEGWRQnVm9eIY7CcQbO5dpdsD9SF8jka3Mr5OqZYGjczGN1+D6EUwdu6phcmcx9iuPA=="
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+        },
+        "esbuild": {
+          "version": "0.19.11",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.11.tgz",
+          "integrity": "sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==",
+          "requires": {
+            "@esbuild/aix-ppc64": "0.19.11",
+            "@esbuild/android-arm": "0.19.11",
+            "@esbuild/android-arm64": "0.19.11",
+            "@esbuild/android-x64": "0.19.11",
+            "@esbuild/darwin-arm64": "0.19.11",
+            "@esbuild/darwin-x64": "0.19.11",
+            "@esbuild/freebsd-arm64": "0.19.11",
+            "@esbuild/freebsd-x64": "0.19.11",
+            "@esbuild/linux-arm": "0.19.11",
+            "@esbuild/linux-arm64": "0.19.11",
+            "@esbuild/linux-ia32": "0.19.11",
+            "@esbuild/linux-loong64": "0.19.11",
+            "@esbuild/linux-mips64el": "0.19.11",
+            "@esbuild/linux-ppc64": "0.19.11",
+            "@esbuild/linux-riscv64": "0.19.11",
+            "@esbuild/linux-s390x": "0.19.11",
+            "@esbuild/linux-x64": "0.19.11",
+            "@esbuild/netbsd-x64": "0.19.11",
+            "@esbuild/openbsd-x64": "0.19.11",
+            "@esbuild/sunos-x64": "0.19.11",
+            "@esbuild/win32-arm64": "0.19.11",
+            "@esbuild/win32-ia32": "0.19.11",
+            "@esbuild/win32-x64": "0.19.11"
+          }
+        },
+        "rollup": {
+          "version": "4.9.4",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.4.tgz",
+          "integrity": "sha512-2ztU7pY/lrQyXSCnnoU4ICjT/tCG9cdH3/G25ERqE3Lst6vl2BCM5hL2Nw+sslAvAf+ccKsAq1SkKQALyqhR7g==",
+          "requires": {
+            "@rollup/rollup-android-arm-eabi": "4.9.4",
+            "@rollup/rollup-android-arm64": "4.9.4",
+            "@rollup/rollup-darwin-arm64": "4.9.4",
+            "@rollup/rollup-darwin-x64": "4.9.4",
+            "@rollup/rollup-linux-arm-gnueabihf": "4.9.4",
+            "@rollup/rollup-linux-arm64-gnu": "4.9.4",
+            "@rollup/rollup-linux-arm64-musl": "4.9.4",
+            "@rollup/rollup-linux-riscv64-gnu": "4.9.4",
+            "@rollup/rollup-linux-x64-gnu": "4.9.4",
+            "@rollup/rollup-linux-x64-musl": "4.9.4",
+            "@rollup/rollup-win32-arm64-msvc": "4.9.4",
+            "@rollup/rollup-win32-ia32-msvc": "4.9.4",
+            "@rollup/rollup-win32-x64-msvc": "4.9.4",
+            "@types/estree": "1.0.5",
+            "fsevents": "~2.3.2"
+          }
+        },
+        "vite": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
+          "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+          "requires": {
+            "esbuild": "^0.19.3",
+            "fsevents": "~2.3.3",
+            "postcss": "^8.4.32",
+            "rollup": "^4.2.0"
+          }
+        },
+        "vue": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.7.tgz",
+          "integrity": "sha512-4urmkWpudekq0CPNMO7p6mBGa9qmTXwJMO2r6CT4EzIJVG7WoSReiysiNb7OSi/WI113oX0Srn9Rz1k/DCXKFQ==",
+          "requires": {
+            "@vue/compiler-dom": "3.4.7",
+            "@vue/compiler-sfc": "3.4.7",
+            "@vue/runtime-dom": "3.4.7",
+            "@vue/server-renderer": "3.4.7",
+            "@vue/shared": "3.4.7"
           }
         }
       }
@@ -9277,16 +10490,6 @@
         "vite-node": "0.33.0",
         "why-is-node-running": "^2.2.2"
       }
-    },
-    "vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
-    },
-    "vscode-textmate": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
     },
     "vue": {
       "version": "3.3.4",

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -26,6 +26,10 @@ export default function getActions(pageDefinition) {
     actions[`set${capitalize(chartKey)}ChartData`] = chartAction;
   }
 
+  if (pageDefinition.extendActions) {
+    Object.assign(actions, pageDefinition.extendActions());
+  }
+
   return {
     ...actions,
     /**

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -259,11 +259,11 @@ export default function getDataHelperFunctions() {
         const upperBound = quartiles["upperQuartile"] + 1.5 * quartiles["IQR"];
         if (idx) {
           return data.filter(
-            (datum) => datum[idx] <= lowerBound || datum[idx] >= upperBound
+            (datum) => datum[idx] <= lowerBound || datum[idx] >= upperBound,
           );
         } else {
           return data.filter(
-            (datum) => datum <= lowerBound || datum >= upperBound
+            (datum) => datum <= lowerBound || datum >= upperBound,
           );
         }
       };
@@ -298,11 +298,11 @@ export default function getDataHelperFunctions() {
         const upperBound = quartiles["upperQuartile"] + 1.5 * quartiles["IQR"];
         if (idx) {
           return data.filter(
-            (datum) => datum[idx] > lowerBound && datum[idx] < upperBound
+            (datum) => datum[idx] > lowerBound && datum[idx] < upperBound,
           );
         } else {
           return data.filter(
-            (datum) => datum > lowerBound && datum < upperBound
+            (datum) => datum > lowerBound && datum < upperBound,
           );
         }
       };

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -81,5 +81,9 @@ export default function getGetters(pageDefinition) {
     };
     getters[`get${capitalize(chartKey)}ChartData`] = getter;
   }
+
+  if (pageDefinition.extendGetters) {
+    Object.assign(getters, pageDefinition.extendGetters());
+  }
   return getters;
 }

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -25,5 +25,9 @@ export default function getState(pageDefinition) {
   for (const chartkey in charts) {
     state[`${chartkey}ChartData`] = null;
   }
+  if (pageDefinition.extendState) {
+    Object.assign(state, pageDefinition.extendState());
+  }
+
   return state;
 }

--- a/src/store/subscriptions.js
+++ b/src/store/subscriptions.js
@@ -43,4 +43,8 @@ function runSubscriptions(name, args, store, pageDefinition, hook) {
       }
     });
   }
+
+  if (pageDefinition.extendSubscriptions) {
+    pageDefinition.extendSubscriptions(name, args, store, pageDefinition, hook);
+  }
 }

--- a/tests/data.spec.js
+++ b/tests/data.spec.js
@@ -29,7 +29,7 @@ describe("DV Data Helpers", () => {
     "1.01",
     new Date(),
   ];
-  let outOfOrderArrayFlat = [4, 1, 3, 1, 2, 4]
+  let outOfOrderArrayFlat = [4, 1, 3, 1, 2, 4];
   it("Can Validate Data", () => {
     let hs = mockHs();
 
@@ -150,7 +150,7 @@ describe("DV Data Helpers", () => {
     // test with all key
     hs.setFilter("filter1", "all");
     expect(hs.applyFilterToColumn("filter1", "test", dataArray, "all")).toEqual(
-      dataArray
+      dataArray,
     );
   });
 
@@ -334,7 +334,7 @@ describe("DV Data Helpers", () => {
       1, 2, 96, 98,
     ]);
     expect(
-      hs.getOutliers(mockSingleRowLowerThanGreaterThanObjects, "field2")
+      hs.getOutliers(mockSingleRowLowerThanGreaterThanObjects, "field2"),
     ).toEqual([
       { field1: 12, field2: 1 },
       { field1: 12, field2: 2 },
@@ -386,7 +386,7 @@ describe("DV Data Helpers", () => {
       39, 41, 43, 45, 49, 52, 55, 57, 59,
     ]);
     expect(
-      hs.removeOutliers(mockSingleRowLowerThanGreaterThanObjects, "field2")
+      hs.removeOutliers(mockSingleRowLowerThanGreaterThanObjects, "field2"),
     ).toEqual([
       { field1: 12, field2: 39 },
       { field1: 12, field2: 41 },

--- a/tests/mocks/pages/TestPage1.js
+++ b/tests/mocks/pages/TestPage1.js
@@ -87,4 +87,27 @@ export default class TestPage1 {
       },
     };
   };
+
+  extendGetters = () => {
+    return {
+      extendedGetter(state) {
+        return state || false;
+      },
+    };
+  };
+  extendActions = () => {
+    return {
+      extendedAction(payload) {
+        this.setFilter("filter1", payload);
+      },
+    };
+  };
+  extendState = () => {
+    return {
+      arbitrary: "test",
+    };
+  };
+  extendSubscriptions = (name, args, store, pageDefinition, hook) => {
+    // console.log(name, args, store, pageDefinition, hook);
+  };
 }

--- a/tests/mocks/pages/TestPage1.js
+++ b/tests/mocks/pages/TestPage1.js
@@ -107,6 +107,7 @@ export default class TestPage1 {
       arbitrary: "test",
     };
   };
+  //eslint-disable-next-line
   extendSubscriptions = (name, args, store, pageDefinition, hook) => {
     // console.log(name, args, store, pageDefinition, hook);
   };

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -45,4 +45,18 @@ describe("DV Helper Init", () => {
       expect(hs[filterKey + "Filter"]).toBeTruthy();
     });
   });
+  it("Has extended getters", () => {
+    let hs = mockHs();
+    expect(hs.extendedGetter).toBeTruthy();
+  });
+  it("Has extended actions", () => {
+    let hs = mockHs();
+    // just wraps setFilter
+    hs.extendedAction("extended");
+    expect(hs.getFilter("filter1")).toEqual("extended");
+  });
+  it("Has extended state", () => {
+    let hs = mockHs();
+    expect(hs.arbitrary).toEqual("test");
+  });
 });


### PR DESCRIPTION
This pull request gives developers the ability to add their own getters, actions, state and action subscriptions to the pinia store generated by harness-vue.

To see the documentation for this feature, pull down this branch and run `npm run docs:dev`, then see the "usage -> extending the store" documentation page.

Roughly, this feature adds the following attributes to the page definition:

* `extendGetters`: a function returning an object of getters to be merged into the pinia store
* `extendActions`: a function returning an object of actions to be merged into the pinia store
* `extendState`: a function returning an object to be merged into the pinia state
* `extendSubscriptions`: a function run on all action subscriptions

--- 

A real world use case inspiring this feature:

In a dashboard we're working on, we retrieve a hierarchical index that defines some of our filter behavior in the application. Currently our workaround is that we retrieve this index file in the initial `loadData` and stick it in `requestCache`, which works for future use in `loadData`. However, this is clunky to use elsewhere in the application, like in `afterSet` functions for a given filter - it requires accessing the `requestCache`, which is an uncommon pattern. It also means retaining this index in `requestCache` as we use it for more normal operations, and also getting at it in templates.

While we could make an individual separate store for this index, it makes sense for a harness developer to be able to extend the definition of their state - this gives developers a tool to use that.