### PR TITLE
Allowing for asynchronous actions in `afterSet` and delegating `loadData` responsibility to `setFilter`

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -8,8 +8,9 @@ export default function getActions(pageDefinition) {
   const actions = {};
   const filters = pageDefinition.filters();
   for (const filterKey in filters) {
-    const filterAction = async function (payload) {
+    const filterAction = async function (payload, triggerLoadData = true) {
       this[`${filterKey}Filter`] = payload;
+      this[`${filterKey}TriggerLoadData`] = triggerLoadData;
     };
     const optionsAction = async function (payload) {
       this[`${filterKey}Options`] = payload;

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -8,10 +8,10 @@ export default function getActions(pageDefinition) {
   const actions = {};
   const filters = pageDefinition.filters();
   for (const filterKey in filters) {
-    const filterAction = function (payload) {
+    const filterAction = async function (payload) {
       this[`${filterKey}Filter`] = payload;
     };
-    const optionsAction = function (payload) {
+    const optionsAction = async function (payload) {
       this[`${filterKey}Options`] = payload;
     };
     actions[`set${capitalize(filterKey)}Filter`] = filterAction;
@@ -67,9 +67,6 @@ export default function getActions(pageDefinition) {
         .loadData(pageDefinition, pageStore)
         .then(function (response) {
           return response;
-        })
-        .catch(function (error) {
-          throw Error(error);
         });
       for (const chartKey in pageDefinition.charts()) {
         if (data[chartKey] === null) {

--- a/src/store/filters.js
+++ b/src/store/filters.js
@@ -246,7 +246,7 @@ export function getFilterActions() {
      * @param  {Boolean} triggerLoadData=true optional variable, if true will trigger a loadData action
      * @memberof module:pageStore
      */
-    setFilter(key, payload, triggerLoadData = true) {
+    setFilter(key, payload, triggerLoadData = false) {
       this._validFilterKey(key);
       this[`set${capitalize(key)}Filter`](payload, triggerLoadData);
     },

--- a/src/store/filters.js
+++ b/src/store/filters.js
@@ -243,11 +243,12 @@ export function getFilterActions() {
      *
      * @param  {String} key a filter key
      * @param  {any} payload a payload to set
+     * @param  {Boolean} triggerLoadData=true optional variable, if true will trigger a loadData action
      * @memberof module:pageStore
      */
-    setFilter(key, payload) {
+    setFilter(key, payload, triggerLoadData = true) {
       this._validFilterKey(key);
-      this[`set${capitalize(key)}Filter`](payload);
+      this[`set${capitalize(key)}Filter`](payload, triggerLoadData);
     },
 
     /**

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -18,6 +18,7 @@ export default function getState(pageDefinition) {
       filters[filterKey].options,
     );
     state[`${filterKey}Options`] = filters[filterKey].options || [];
+    state[`${filterKey}TriggerLoadData`] = true;
   }
 
   // add chart data container for each chart type

--- a/src/store/subscriptions.js
+++ b/src/store/subscriptions.js
@@ -1,50 +1,84 @@
 import { capitalize } from "./utils.js";
 
 export default function subscribeActions(store, pageDefinition) {
-  store.$onAction(({ name, store, args, after }) => {
+  store.$onAction(async ({ name, store, args, after }) => {
     //before action is called
-    runSubscriptions(name, args, store, pageDefinition, "before");
-    after(() => {
-      runSubscriptions(name, args, store, pageDefinition, "after");
+    after(async () => {
+      await runSubscriptions(name, args, store, pageDefinition, "after");
+      await checkForLoadData(name, store);
     });
+
+    await runSubscriptions(name, args, store, pageDefinition, "before");
   });
 }
 
-function runSubscriptions(name, args, store, pageDefinition, hook) {
+async function runSubscriptions(name, args, store, pageDefinition, hook) {
   // for loadData actions, both toggle the dataLoading state variable
   // and also check for before/after loadData hooks
   if (name === "loadData") {
     store.toggleDataLoading();
     if (pageDefinition[`${hook}LoadData`]) {
-      pageDefinition[`${hook}LoadData`]({ name, args }, store);
+      await pageDefinition[`${hook}LoadData`]({ name, args }, store);
     }
   } else if (name.includes("Filter") && name !== "setFilter") {
     // iterate over filters to find if any match the action name
     // and run their before/after hooks
-    Object.keys(store.getFilters).forEach((filterKey) => {
-      const filterActionString = `set${capitalize(filterKey)}Filter`;
-      if (
-        name === filterActionString &&
-        store.getFilters[filterKey][`${hook}Set`]
-      ) {
-        store.getFilters[filterKey][`${hook}Set`]({ name, args }, store);
-      }
-    });
+    await Promise.all(
+      Object.keys(store.getFilters).map(async (filterKey) => {
+        const filterActionString = `set${capitalize(filterKey)}Filter`;
+        if (
+          name === filterActionString &&
+          store.getFilters[filterKey][`${hook}Set`]
+        ) {
+          await store.getFilters[filterKey][`${hook}Set`](
+            { name, args },
+            store,
+          );
+        }
+      }),
+    );
   } else if (name.includes("ChartData") && name !== "setChartData") {
-    // iterate over hcarts to find if any match the action name
+    // iterate over charts to find if any match the action name
     // and run their before/after hooks
-    Object.keys(store.getCharts).forEach((chartKey) => {
-      const chartActionString = `set${capitalize(chartKey)}ChartData`;
-      if (
-        name === chartActionString &&
-        store.getCharts[chartKey][`${hook}Set`]
-      ) {
-        store.getCharts[chartKey][`${hook}Set`]({ name, args }, store);
-      }
-    });
+    await Promise.all(
+      Object.keys(store.getCharts).map(async (chartKey) => {
+        const chartActionString = `set${capitalize(chartKey)}ChartData`;
+        if (
+          name === chartActionString &&
+          store.getCharts[chartKey][`${hook}Set`]
+        ) {
+          await store.getCharts[chartKey][`${hook}Set`]({ name, args }, store);
+        }
+      }),
+    );
   }
 
   if (pageDefinition.extendSubscriptions) {
     pageDefinition.extendSubscriptions(name, args, store, pageDefinition, hook);
+  }
+  return Promise.resolve();
+}
+
+// checks to see if the action is a filter action and if so, checks if the filter is synchronous
+// if not, it will trigger a loadData action
+async function checkForLoadData(name, store) {
+  if (name.includes("Filter") && name !== "setFilter") {
+    // get filter name from action
+    const filterName = name.slice(3, -6);
+    // find the matching filter key and retrieve definition
+    const filterKey = store.getFilterKeys.find(
+      (filter) => capitalize(filter) === filterName,
+    );
+    const filterObj = store.getFilterDefinition(filterKey);
+
+    if (
+      store[`${filterKey}TriggerLoadData`] &&
+      !(
+        Object.hasOwn(filterObj, "triggerLoadData") &&
+        filterObj.triggerLoadData == false
+      )
+    ) {
+      await store.loadData();
+    }
   }
 }

--- a/src/store/subscriptions.js
+++ b/src/store/subscriptions.js
@@ -69,16 +69,17 @@ async function checkForLoadData(name, store) {
     const filterKey = store.getFilterKeys.find(
       (filter) => capitalize(filter) === filterName,
     );
-    const filterObj = store.getFilterDefinition(filterKey);
-
-    if (
-      store[`${filterKey}TriggerLoadData`] &&
-      !(
-        Object.hasOwn(filterObj, "triggerLoadData") &&
-        filterObj.triggerLoadData == false
-      )
-    ) {
-      await store.loadData();
+    if (filterKey) {
+      const filterObj = store.getFilterDefinition(filterKey);
+      if (
+        store[`${filterKey}TriggerLoadData`] &&
+        !(
+          Object.hasOwn(filterObj, "triggerLoadData") &&
+          filterObj.triggerLoadData == false
+        )
+      ) {
+        await store.loadData();
+      }
     }
   }
 }

--- a/src/store/subscriptions.js
+++ b/src/store/subscriptions.js
@@ -70,14 +70,8 @@ async function checkForLoadData(name, store) {
       (filter) => capitalize(filter) === filterName,
     );
     if (filterKey) {
-      const filterObj = store.getFilterDefinition(filterKey);
-      if (
-        store[`${filterKey}TriggerLoadData`] &&
-        !(
-          Object.hasOwn(filterObj, "triggerLoadData") &&
-          filterObj.triggerLoadData == false
-        )
-      ) {
+      // check to see if last run of setFilter enabled triggerLoadData
+      if (store[`${filterKey}TriggerLoadData`]) {
         await store.loadData();
       }
     }


### PR DESCRIPTION
This pull request is in response to #20.

In getting a subset of features implemented in the MBEE application, we found that `beforeSet`, `afterSet`, and `loadData` were all simultaneously firing - asynchronous behavior such as `fetch` requests were not properly `awaited`.


## Context
In Harness applications, it is generally expected that setting a filter runs the `loadData` function. This is actually not a convention in `harness-vue`, but a convention in `harness-vue-bootstrap`, which are typically used in combination. All form control components in `harness-vue-bootstrap` use the same `boundValue` ([link](https://github.com/RTIInternational/harness-vue-bootstrap/blob/main/src/components/inputs/utils/useBoundValue.js)) computed function as a getter/setter in a two-way bind using Vue's [v-model](https://vuejs.org/guide/components/v-model.html). This `boundValue` implementation checks for a `synchronous` prop, a `harness-vue-bootstrap` convention, and runs `loadData`.

`harness-vue` provides `beforeSet` and `afterSet` hooks to all filters, which use pinia's [action susbcriptions](https://pinia.vuejs.org/core-concepts/actions.html#Subscribing-to-actions) to run before/after the `setFilter` action for a specific filter fires.

## Problem
The initial discovery of an issue was for the MBEE project. In this project, the filter options lived on the server side, so there were frequent `fetch` requests being triggered in `beforeSet` and `afterSet` hooks. For example, setting filter A might trigger a fetch request to the server which is used to set the options and new default value for filter B.

What we noticed was that none of these fetch requests were properly `await`ed - `beforeSet`, `loadData` and `afterSet` were seemingly triggered simultaneously and resolved independently.

The problem here was twofold - first, none of the `harness-vue` action subscription implementation was asynchronous. Second, the `boundValue` computed setter in `harness-vue-bootstrap` runs `setFilter` and `loadData` independently. Because of the design of the pinia subscriptions, there is no way to have the `setFilter` function wait for any `after` effects to resolve as part of its own promise resolution.

## Solution
The solution to the first problem was easy(ish) - we revised the implementation of `setFilter` and `loadData` to be asynchronous, as well as the subscription implementation. What we found in doing so is that pinia's action subscriptions handle `after` effects asynchronously, but not `before` effects. This seems to be intended, and means that in our implementation, we can expect that `after` effects are properly asynchronous, but `before` effects are not - which is fine and is a limitation we can document.

However, given how these things resolve independently, there was not a way to have `harness-vue-bootstrap` wait for the `afterSet`'s promise resolution before running `loadData`.

Our solution is instead to bring this behavior into `harness-vue`. In this implementation we have changed the API so that `synchronous` is no longer a prop defined by `harness-vue-bootstrap`, but is instead now an attribute on `harness-vue` filters called `triggerLoadData` that defaults to `false`. This allows us to move the `loadData` call into the action subscription, so that we can properly expect a linear progression from `setFilter` -> `afterSet` -> `loadData`.

In doing so, we realized that sometimes we call `setFilter` in `loadData` or `afterSet` functions, but don't necessarily want to spawn a duplicate `loadData` call. To alleviate this, we added an optional parameter to `setFilter` (defaulting to `true`) that tells `harness-vue` whether or not to call `loadData` after the resolution of `setFilter` and `afterSet`.

To summarize the proposed API changes:

- `loadData` is now a direct result of `setFilter`
- `setFilter` can now be called as `setFilter(key, payload, triggerLoadData = true)`
- filters can be given an attribute of `triggerLoadData: false` if you would never like them to trigger `loadData` as a side effect


I'm pausing here to check with the team in a call on Monday as to what ramifications this may have on existing codebases. I have a few thoughts that I'll capture there - specifically around the `triggerLoadData` parameter of `setFilter`. 
